### PR TITLE
Implements Framesections, Wallsections, and Connections

### DIFF
--- a/InputSheetBM/BeamInputWidget.cpp
+++ b/InputSheetBM/BeamInputWidget.cpp
@@ -94,7 +94,7 @@ BeamInputWidget::~BeamInputWidget()
 
 }
 
-void
+bool
 BeamInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // create a json array and for each row add a json object to it
@@ -197,9 +197,11 @@ BeamInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // finally add the array to the input arg
     jsonObj["beams"]=jsonArray;
+
+    return(true);
 }
 
-void
+bool
 BeamInputWidget::inputFromJSON(QJsonObject &jsonObject){
 
 
@@ -283,7 +285,7 @@ BeamInputWidget::inputFromJSON(QJsonObject &jsonObject){
         currentRow++;
     }
 
-
+    return(true);
 }
 
 void

--- a/InputSheetBM/BeamInputWidget.h
+++ b/InputSheetBM/BeamInputWidget.h
@@ -51,8 +51,8 @@ public:
     explicit BeamInputWidget(SimCenterWidget *parent = 0);
     ~BeamInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/BraceInputWidget.cpp
+++ b/InputSheetBM/BraceInputWidget.cpp
@@ -95,7 +95,7 @@ BraceInputWidget::~BraceInputWidget()
 
 }
 
-void
+bool
 BraceInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // create a json array and for each row add a json object to it
@@ -200,9 +200,11 @@ BraceInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // finally add the array to the input arg
     jsonObj["braces"]=jsonArray;
+
+    return(true);
 }
 
-void
+bool
 BraceInputWidget::inputFromJSON(QJsonObject &jsonObject){
 
 
@@ -289,8 +291,7 @@ BraceInputWidget::inputFromJSON(QJsonObject &jsonObject){
         currentRow++;
     }
 
-
-
+    return(true);
 }
 
 void

--- a/InputSheetBM/BraceInputWidget.h
+++ b/InputSheetBM/BraceInputWidget.h
@@ -51,8 +51,8 @@ public:
     explicit BraceInputWidget(QWidget *parent = 0);
     ~BraceInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/ClineInputWidget.cpp
+++ b/InputSheetBM/ClineInputWidget.cpp
@@ -66,7 +66,7 @@ ClineInputWidget::~ClineInputWidget()
 
 }
 
-void
+bool
 ClineInputWidget::outputToJSON(QJsonObject &jsonObj){
 
      // create a json array and for each row add a json object to it
@@ -97,10 +97,11 @@ ClineInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // finally add the array to the input arg
     jsonObj["clines"]=jsonArrayCline;
+    return(true);
 
 }
 
-void
+bool
 ClineInputWidget::inputFromJSON(QJsonObject &jsonObject)
 {
     int currentRow = 0;
@@ -131,6 +132,7 @@ ClineInputWidget::inputFromJSON(QJsonObject &jsonObject)
 
         currentRow++;
     }
+    return(true);
 }
 
 void

--- a/InputSheetBM/ClineInputWidget.h
+++ b/InputSheetBM/ClineInputWidget.h
@@ -52,10 +52,10 @@ public:
     explicit ClineInputWidget(QWidget *parent = 0);
     ~ClineInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
-    void outputToJSON(QJsonArray &arrayObject);
-    void inputFromJSON(QJsonArray &arrayObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonArray &arrayObject);
+    bool inputFromJSON(QJsonArray &arrayObject);
 
     void clear(void);
 

--- a/InputSheetBM/ColumnInputWidget.cpp
+++ b/InputSheetBM/ColumnInputWidget.cpp
@@ -93,7 +93,7 @@ ColumnInputWidget::~ColumnInputWidget()
 
 }
 
-void
+bool
 ColumnInputWidget::outputToJSON(QJsonObject &jsonObj){
 
      // create a json array and for each row add a json object to it
@@ -188,9 +188,11 @@ ColumnInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // finally add the array to the input arg
     jsonObj["columns"]=jsonArray;
+
+    return(true);
 }
 
-void
+bool
 ColumnInputWidget::inputFromJSON(QJsonObject &jsonObject){
 
     QString name;
@@ -271,7 +273,7 @@ ColumnInputWidget::inputFromJSON(QJsonObject &jsonObject){
         }
         currentRow++;
     }
-
+    return(true);
 }
 
 void

--- a/InputSheetBM/ColumnInputWidget.h
+++ b/InputSheetBM/ColumnInputWidget.h
@@ -51,8 +51,8 @@ public:
     explicit ColumnInputWidget(QWidget *parent = 0);
     ~ColumnInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/ConcreteInputWidget.cpp
+++ b/InputSheetBM/ConcreteInputWidget.cpp
@@ -80,14 +80,14 @@ ConcreteInputWidget::~ConcreteInputWidget()
 
 }
 
-void
+bool
 ConcreteInputWidget::outputToJSON(QJsonObject &jsonObj){
-    return;
+    return(true);
 }
 
-void
+bool
 ConcreteInputWidget::outputToJSON(QJsonArray &jsonArray){
-\
+
     int numRows = theSpreadsheet->getNumRows();
     for (int i=0; i<numRows; i++) {
 
@@ -133,9 +133,10 @@ ConcreteInputWidget::outputToJSON(QJsonArray &jsonArray){
         // add the object to the array
         jsonArray.append(obj);
     }
+    return(true);
 }
 
-void
+bool
 ConcreteInputWidget::inputFromJSON(QJsonObject &theObject)
 {
     // this has to be called one object at a time for efficiency
@@ -173,6 +174,7 @@ ConcreteInputWidget::inputFromJSON(QJsonObject &theObject)
 
         currentRow++;
     }
+    return(true);
 }
 
 void

--- a/InputSheetBM/ConcreteInputWidget.h
+++ b/InputSheetBM/ConcreteInputWidget.h
@@ -51,9 +51,9 @@ public:
     explicit ConcreteInputWidget(QWidget *parent = 0);
     ~ConcreteInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-     void outputToJSON(QJsonArray &arrayObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonArray &arrayObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/ConnectionInputWidget.cpp
+++ b/InputSheetBM/ConnectionInputWidget.cpp
@@ -129,10 +129,10 @@ ConnectionInputWidget::~ConnectionInputWidget()
 
 }
 
-void
-ConnectionInputWidget::outputToJSON(QJsonObject &jsonObj){return;}
+bool
+ConnectionInputWidget::outputToJSON(QJsonObject &jsonObj){return(true);}
 
-void
+bool
 ConnectionInputWidget::outputToJSON(QJsonArray &jsonArray){
     int numRows = theSpreadsheet->getNumRows();
 
@@ -151,7 +151,7 @@ ConnectionInputWidget::outputToJSON(QJsonArray &jsonArray){
                 if (theSpreadsheet->getString(i,j,tmpString) == false || tmpString.isEmpty()) {
                     qDebug() << "no value for " << fieldName << " in row " << i;
                     // TODO: need to actually break out of this loop
-                    return;
+                    return(true);
                 }
                 if (fieldName.startsWith("bolt group ") == true) {
                     boltGroup[fieldName.remove(0,11)] = tmpString;
@@ -164,7 +164,7 @@ ConnectionInputWidget::outputToJSON(QJsonArray &jsonArray){
                 if (theSpreadsheet->getDouble(i,j,tmpDouble) == false) {
                     qDebug() << "no value for " << fieldName << " in row " << i;
                     // TODO: need to actually break out of this loop
-                    return;
+                    return(true);
                 }
                 if (fieldName.startsWith("bolt group ") == true) {
                     boltGroup[fieldName.remove(0,11)] = tmpDouble;
@@ -178,13 +178,13 @@ ConnectionInputWidget::outputToJSON(QJsonArray &jsonArray){
         obj["type"] = connectionType;
         jsonArray.append(obj);
     }
-
+    return(true);
 }
 
-void
-ConnectionInputWidget::inputFromJSON(QJsonObject &jsonObject){return;}
+bool
+ConnectionInputWidget::inputFromJSON(QJsonObject &jsonObject){return(true);}
 
-void
+bool
 ConnectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
     int currentRow = 0;
 
@@ -217,6 +217,7 @@ ConnectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
             currentRow++;
         }
     }
+    return(true);
 }
 
 void

--- a/InputSheetBM/ConnectionInputWidget.cpp
+++ b/InputSheetBM/ConnectionInputWidget.cpp
@@ -102,7 +102,27 @@ ConnectionInputWidget::ConnectionInputWidget(SimCenterWidget *parent) : SimCente
     this->setMinimumWidth(500);
 }
 
+ConnectionInputWidget::ConnectionInputWidget(QString connectionType, SimCenterWidget *parent) : SimCenterTableWidget(parent)
+{
+    if (connectionType == "gusset with foldline") { this->gussetConnection(); }
+    if (connectionType == "gusset without foldline") { this->gussetConnection(); }
+    if (connectionType == "baseplate gusset with foldline") { this->baseplateConnection(); }
+    if (connectionType == "baseplate gusset without foldline") { this->baseplateConnection(); }
+    if (connectionType == "welded shear tab") { this->weldedShearTab(); }
+    if (connectionType == "bolted shear tab") { this->boltedShearTab(); }
 
+    this->connectionType = connectionType;
+    this->setupSpreadsheet();
+}
+
+ConnectionInputWidget::ConnectionInputWidget(QStringList headings, QList<int> dataTypes, QString connectionType, SimCenterWidget *parent) : SimCenterTableWidget(parent)
+{
+    this->tableHeader = headings;
+    this->dataTypes = dataTypes;
+    this->connectionType = connectionType;
+
+    this->setupSpreadsheet();
+}
 
 ConnectionInputWidget::~ConnectionInputWidget()
 {
@@ -110,172 +130,204 @@ ConnectionInputWidget::~ConnectionInputWidget()
 }
 
 void
-ConnectionInputWidget::outputToJSON(QJsonObject &jsonObj){
+ConnectionInputWidget::outputToJSON(QJsonObject &jsonObj){return;}
 
-
-    QJsonArray  jsonArray;
+void
+ConnectionInputWidget::outputToJSON(QJsonArray &jsonArray){
     int numRows = theSpreadsheet->getNumRows();
+
+    // for each row of the spreadsheet
     for (int i=0; i<numRows; i++) {
+        QJsonObject obj, boltGroup;
+        // for each field defined in private member var tableHeader
+        // and the respective data type defined in private member var dataTypes
+        // (tableHeader and dataTypes defined in constructor function)
+        for (int j=0; j<tableHeader.size(); j++) {
+            QString fieldName = tableHeader[j].toLower();
 
-        QJsonObject obj;
-        QString name, type, material;
-        double thickness, weld_len_brace, weld_len_beam, weld_len_column, weld_len_baseplate, thickness_baseplate, workpoint_depth, tab_depth, tab_width;
+            if(dataTypes[j] == 0) {
+                //string
+                QString tmpString;
+                if (theSpreadsheet->getString(i,j,tmpString) == false || tmpString.isEmpty()) {
+                    qDebug() << "no value for " << fieldName << " in row " << i;
+                    // TODO: need to actually break out of this loop
+                    return;
+                }
+                if (fieldName.startsWith("bolt group ") == true) {
+                    boltGroup[fieldName.remove(0,11)] = tmpString;
+                } else {
+                    obj[fieldName] = tmpString;
+                }
+            } else if (dataTypes[j] == 1) {
+                //double
+                double tmpDouble;
+                if (theSpreadsheet->getDouble(i,j,tmpDouble) == false) {
+                    qDebug() << "no value for " << fieldName << " in row " << i;
+                    // TODO: need to actually break out of this loop
+                    return;
+                }
+                if (fieldName.startsWith("bolt group ") == true) {
+                    boltGroup[fieldName.remove(0,11)] = tmpDouble;
+                } else {
+                    obj[fieldName] = tmpDouble;
+                }
+            }
+        }
 
-        // bolt group
-        QString pattern;
-        double edge_dist_depth, edge_dist_width, num_bolts_depth, num_bolts_width;
-
-        // obtain info from spreadsheet
-        if (theSpreadsheet->getString(i,0,name) == false || name.isEmpty())
-            break;
-        if (theSpreadsheet->getString(i,1,type) == false)
-            break;
-        if (theSpreadsheet->getString(i,2, material) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,3,thickness) == false)
-            break;
-
-        if (theSpreadsheet->getDouble(i,4,weld_len_baseplate) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,5,weld_len_beam) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,6,weld_len_brace) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,7,weld_len_column) == false)
-            break;
-
-        if (theSpreadsheet->getDouble(i,8,thickness_baseplate) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,9,workpoint_depth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,10,tab_depth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,11,tab_width) == false)
-            break;
-
-        // bolt group
-        if (theSpreadsheet->getDouble(i,12,edge_dist_depth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,13,edge_dist_width) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,14,num_bolts_depth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,15,num_bolts_width) == false)
-            break;
-        if (theSpreadsheet->getString(i,16,pattern) == false || name.isEmpty())
-            break;
-
-        // now add the items to object
-        obj["name"]=name;
-        obj["type"]=type;
-        obj["material"]=material;
-        obj["thickness"]=thickness;
-
-        obj["weld length baseplate"]=weld_len_baseplate;
-        obj["weld length beam"]=weld_len_beam;
-        obj["weld length brace"]=weld_len_brace;
-        obj["weld length column"]=weld_len_column;
-
-        //bolt group
-        QJsonObject boltgroup;
-
-        boltgroup["edge distance depth"]=edge_dist_depth;
-        boltgroup["edge distance width"]=edge_dist_width;
-        boltgroup["number of bolts depth"]=num_bolts_depth;
-        boltgroup["number of bolts width"]=num_bolts_width;
-        boltgroup["bar area corner"]=pattern;
-
-        obj["bolt group"] = boltgroup;
-
-
-        // add the object to the array
-       jsonArray.append(obj);
-
+        if(!boltGroup.isEmpty()) { obj["bolt group"] = boltGroup; }
+        obj["type"] = connectionType;
+        jsonArray.append(obj);
     }
-
-    // add the object
-    jsonObj["connections"] = jsonArray;
 
 }
 
 void
-ConnectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
+ConnectionInputWidget::inputFromJSON(QJsonObject &jsonObject){return;}
 
+void
+ConnectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
     int currentRow = 0;
 
-    QString name, type, material;
-    double thickness, weld_len_brace, weld_len_beam, weld_len_column, weld_len_baseplate, thickness_baseplate, workpoint_depth, tab_depth, tab_width;
-
-    // bolt group
-    QString pattern;
-    double edge_dist_depth, edge_dist_width, num_bolts_depth, num_bolts_width;
-
-    //
-    //
-
-    QJsonArray theArray = jsonObject["connections"].toArray();
-    foreach (const QJsonValue &theValue, theArray) {
-        // get values
+    foreach (const QJsonValue &theValue, jsonArray) {
         QJsonObject theObject = theValue.toObject();
+        if (theObject["type"] == connectionType) {
+            QJsonObject boltGroup = theObject["bolt group"].toObject();
 
-        name = theObject["name"].toString();
-        type = theObject["type"].toString();
-        material = theObject["material"].toString();
-        thickness = theObject["thickness"].toDouble();
+            for (int j=0; j<tableHeader.size(); j++) {
+                QString fieldName = tableHeader[j].toLower();
 
-        weld_len_baseplate = theObject["weld length baseplate"].toDouble();
-        weld_len_beam = theObject["weld length beam"].toDouble();
-        weld_len_brace = theObject["weld length brace"].toDouble();
-        weld_len_column = theObject["weld length column"].toDouble();
-
-        thickness_baseplate = theObject["thickness baseplate"].toDouble();
-        workpoint_depth = theObject["workpoint depth"].toDouble();
-        tab_depth = theObject["tab depth"].toDouble();
-        tab_width = theObject["tab width"].toDouble();
-
-        // bolt group
-        QJsonValue theBGValue = theObject["bolt group"];
-        QJsonObject bgObject = theBGValue.toObject();
-
-        edge_dist_depth = theObject["edge distance depth"].toDouble();
-        edge_dist_width = theObject["edge distance width"].toDouble();
-        num_bolts_depth = theObject["number of bolts depth"].toDouble();
-        num_bolts_width = theObject["number of bolts width"].toDouble();
-        pattern = theObject["pattern"].toString();
-
-
-        // add to the spreadsheet
-        theSpreadsheet->setString(currentRow, 0, name);
-        theSpreadsheet->setString(currentRow, 1, type);
-        theSpreadsheet->setString(currentRow, 2, material);
-        theSpreadsheet->setDouble(currentRow, 3, thickness);
-
-        theSpreadsheet->setDouble(currentRow, 4, weld_len_baseplate);
-        theSpreadsheet->setDouble(currentRow, 5, weld_len_beam);
-        theSpreadsheet->setDouble(currentRow, 6, weld_len_brace);
-        theSpreadsheet->setDouble(currentRow, 7, weld_len_column);
-
-        theSpreadsheet->setDouble(currentRow, 8, thickness_baseplate);
-        theSpreadsheet->setDouble(currentRow, 9, workpoint_depth);
-        theSpreadsheet->setDouble(currentRow, 10, tab_depth);
-        theSpreadsheet->setDouble(currentRow, 11, tab_width);
-
-        // bolt group
-        theSpreadsheet->setDouble(currentRow, 12, edge_dist_depth);
-        theSpreadsheet->setDouble(currentRow, 13, edge_dist_width);
-        theSpreadsheet->setDouble(currentRow, 14, num_bolts_depth);
-        theSpreadsheet->setDouble(currentRow, 15, num_bolts_width);
-        theSpreadsheet->setString(currentRow, 16, pattern);
-
-        currentRow++;
+                if(dataTypes[j] == 0) {
+                    QString tmpString;
+                    if(fieldName.startsWith("bolt group ") == true) {
+                        tmpString = boltGroup[fieldName.remove(0,11)].toString();
+                    } else {
+                        tmpString = theObject[fieldName].toString();
+                    }
+                    theSpreadsheet->setString(currentRow, j, tmpString);
+                } else if (dataTypes[j] == 1) {
+                    double tmpDouble;
+                    if(fieldName.startsWith("bolt group ") == true) {
+                        tmpDouble = boltGroup[fieldName.remove(0,11)].toDouble();
+                    } else {
+                        tmpDouble = theObject[fieldName].toDouble();
+                    }
+                    theSpreadsheet->setDouble(currentRow, j, tmpDouble);
+                }
+            }
+            currentRow++;
+        }
     }
-
-
 }
-
 
 void
 ConnectionInputWidget::clear(void)
 {
     theSpreadsheet->clear();
+}
+
+void
+ConnectionInputWidget::setupSpreadsheet() {
+    theLayout = new QHBoxLayout();
+    this->setLayout(theLayout);
+    theSpreadsheet = new SpreadsheetWidget(tableHeader.size(), 1000, tableHeader, dataTypes, this);
+    theLayout->addWidget(theSpreadsheet);
+    this->setMinimumWidth(500);
+}
+
+void
+ConnectionInputWidget::gussetConnection() {
+    QStringList gussetHeadings;
+    QList<int> gussetDataTypes;
+
+    gussetHeadings << tr("Name");
+    gussetDataTypes << SIMPLESPREADSHEET_QString;
+    gussetHeadings << tr("material");
+    gussetDataTypes << SIMPLESPREADSHEET_QDouble;
+    gussetHeadings << tr("thickness");
+    gussetDataTypes << SIMPLESPREADSHEET_QDouble;
+    gussetHeadings << tr("weld length brace");
+    gussetDataTypes << SIMPLESPREADSHEET_QDouble;
+    gussetHeadings << tr("weld length column");
+    gussetDataTypes << SIMPLESPREADSHEET_QDouble;
+    gussetHeadings << tr("weld length beam");
+    gussetDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = gussetHeadings;
+    this->dataTypes = gussetDataTypes;
+}
+
+void
+ConnectionInputWidget::baseplateConnection() {
+    QStringList baseplateHeadings;
+    QList<int> baseplateDataTypes;
+
+    baseplateHeadings << tr("Name");
+    baseplateDataTypes << SIMPLESPREADSHEET_QString;
+    baseplateHeadings << tr("material");
+    baseplateDataTypes << SIMPLESPREADSHEET_QDouble;
+    baseplateHeadings << tr("thickness");
+    baseplateDataTypes << SIMPLESPREADSHEET_QDouble;
+    baseplateHeadings << tr("weld length brace");
+    baseplateDataTypes << SIMPLESPREADSHEET_QDouble;
+    baseplateHeadings << tr("weld length column");
+    baseplateDataTypes << SIMPLESPREADSHEET_QDouble;
+    baseplateHeadings << tr("weld length baseplate");
+    baseplateDataTypes << SIMPLESPREADSHEET_QDouble;
+    baseplateHeadings << tr("thickness baseplate");
+    baseplateDataTypes << SIMPLESPREADSHEET_QDouble;
+    baseplateHeadings << tr("workpoint depth");
+    baseplateDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = baseplateHeadings;
+    this->dataTypes = baseplateDataTypes;
+}
+
+void
+ConnectionInputWidget::weldedShearTab() {
+    QStringList weldedShearTabHeadings;
+    QList<int> weldedShearTabDataTypes;
+
+    weldedShearTabHeadings << tr("Name");
+    weldedShearTabDataTypes << SIMPLESPREADSHEET_QString;
+    weldedShearTabHeadings << tr("material");
+    weldedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    weldedShearTabHeadings << tr("thickness");
+    weldedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    weldedShearTabHeadings << tr("tab width");
+    weldedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    weldedShearTabHeadings << tr("tab depth");
+    weldedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = weldedShearTabHeadings;
+    this->dataTypes = weldedShearTabDataTypes;
+}
+
+void
+ConnectionInputWidget::boltedShearTab() {
+    QStringList boltedShearTabHeadings;
+    QList<int> boltedShearTabDataTypes;
+
+    boltedShearTabHeadings << tr("Name");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QString;
+    boltedShearTabHeadings << tr("material");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("thickness");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("tab width");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("tab depth");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("bolt group edge distance depth");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("bolt group edge distance width");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("bolt group number of bolts depth");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("bolt group number of bolts width");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+    boltedShearTabHeadings << tr("bolt group pattern");
+    boltedShearTabDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = boltedShearTabHeadings;
+    this->dataTypes = boltedShearTabDataTypes;
 }

--- a/InputSheetBM/ConnectionInputWidget.h
+++ b/InputSheetBM/ConnectionInputWidget.h
@@ -51,10 +51,15 @@ class ConnectionInputWidget : public SimCenterTableWidget
 public:    
 
     explicit ConnectionInputWidget(SimCenterWidget *parent = 0);
+    explicit ConnectionInputWidget(QString connectionType, SimCenterWidget *parent = 0);
+    explicit ConnectionInputWidget(QStringList headings, QList<int> dataTypes, QString connectionType, SimCenterWidget *parent = 0);
+
     ~ConnectionInputWidget();
 
     void outputToJSON(QJsonObject &rvObject);
+    void outputToJSON(QJsonArray &rvObject);
     void inputFromJSON(QJsonObject &rvObject);
+    void inputFromJSON(QJsonArray &rvObject);
     void clear(void);
 
 signals:
@@ -64,7 +69,14 @@ public slots:
 private:
     QHBoxLayout *theLayout;
     QStringList   tableHeader;
+    QList<int> dataTypes;
+    QString connectionType;
 
+    void setupSpreadsheet();
+    void gussetConnection();
+    void baseplateConnection();
+    void weldedShearTab();
+    void boltedShearTab();
 };
 
 #endif // CONNECTIONINPUTWIDGET_H

--- a/InputSheetBM/ConnectionInputWidget.h
+++ b/InputSheetBM/ConnectionInputWidget.h
@@ -56,10 +56,10 @@ public:
 
     ~ConnectionInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void outputToJSON(QJsonArray &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonArray &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonArray &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonArray &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/FloorInputWidget.cpp
+++ b/InputSheetBM/FloorInputWidget.cpp
@@ -64,7 +64,7 @@ FloorInputWidget::~FloorInputWidget()
 
 }
 
-void
+bool
 FloorInputWidget::outputToJSON(QJsonObject &jsonObj){
 
       // create a json array and for each row add a json object to it
@@ -92,9 +92,11 @@ FloorInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // finally add the array to the input arg
     jsonObj["floors"]=jsonArray;
+
+    return(true);
 }
 
-void
+bool
 FloorInputWidget::inputFromJSON(QJsonObject &jsonObject)
 {
     int currentRow = 0;
@@ -119,6 +121,7 @@ FloorInputWidget::inputFromJSON(QJsonObject &jsonObject)
 
         currentRow++;
     }
+    return(true);
 }
 
 void

--- a/InputSheetBM/FloorInputWidget.h
+++ b/InputSheetBM/FloorInputWidget.h
@@ -52,8 +52,8 @@ public:
     explicit FloorInputWidget(QWidget *parent = 0);
     ~FloorInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/FramesectionInputWidget.cpp
+++ b/InputSheetBM/FramesectionInputWidget.cpp
@@ -42,91 +42,33 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <QDebug>
 #include <QList>
 
-FramesectionInputWidget::FramesectionInputWidget(SimCenterWidget *parent) : SimCenterTableWidget(parent)
+FramesectionInputWidget::FramesectionInputWidget(QString framesectionType, SimCenterWidget *parent) : SimCenterTableWidget(parent)
+{
+    if (framesectionType == "concrete rectangular column") { this->concreteRectColFS(); }
+    if (framesectionType == "concrete box column") { this->concreteBoxColFS(); }
+    if (framesectionType == "concrete circular column") { this->concreteCircColFS(); }
+    if (framesectionType == "concrete pipe column") { this->concretePipeColFS(); }
+
+    theLayout = new QHBoxLayout();
+    this->setLayout(theLayout);
+
+    theSpreadsheet = new SpreadsheetWidget(this->tableHeader.size(), 1000, this->tableHeader, this->dataTypes, this);
+    theLayout->addWidget(theSpreadsheet);
+    this->setMinimumWidth(500);
+}
+
+FramesectionInputWidget::FramesectionInputWidget(QStringList headings, QList<int> dataTypes, QString framesectionType, SimCenterWidget *parent) : SimCenterTableWidget(parent)
 {
     theLayout = new QHBoxLayout();
     this->setLayout(theLayout);
 
-    QStringList headings;
-    QList<int> dataTypes;
-    headings << tr("Name");
-    dataTypes << SIMPLESPREADSHEET_QString;
-    headings << tr("Type");
-    dataTypes << SIMPLESPREADSHEET_QString;
-    headings << tr("Material");
-    dataTypes << SIMPLESPREADSHEET_QString;
-
-    headings << tr("Depth");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("Width");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("Shape");
-    dataTypes << SIMPLESPREADSHEET_QString;
-
-    headings << tr("thickness");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("weld length brace");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("weld length column");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("weld length baseplate");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("thickness baseplate");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("workpoint depth");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("top flange width");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("top flange thickness");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("web thickness");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("bottom flange width");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("bottom flange thickness");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("fillet radius");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("corner radius");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    headings << tr("longitudinal rebar material");
-    dataTypes << SIMPLESPREADSHEET_QString;
-    headings << tr("longitudinal rebar material corner");
-    dataTypes << SIMPLESPREADSHEET_QString;
-    headings << tr("longitudinal rebar num bars depth");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("longitudinal rebar num bars width");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("longitudinal rebar bar area");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("longitudinal rebar bar area corner");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("longitudinal rebar cover");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    headings << tr("transverse rebar material");
-    dataTypes << SIMPLESPREADSHEET_QString;
-    headings << tr("transverse rebar num bars depth");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("transverse rebar num bars width");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("transverse rebar num bars thickness");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("transverse rebar bar area");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("transverse rebar spacing");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    headings << tr("transverse rebar cover");
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
     theSpreadsheet = new SpreadsheetWidget(headings.size(), 1000, headings, dataTypes, this);
-
     theLayout->addWidget(theSpreadsheet);
 
     this->setMinimumWidth(500);
     this->tableHeader = headings;
     this->dataTypes = dataTypes;
+    this->framesectionType = framesectionType;
 }
 
 
@@ -135,46 +77,209 @@ FramesectionInputWidget::~FramesectionInputWidget()
 
 }
 
-void
-FramesectionInputWidget::outputToJSON(QJsonObject &jsonObj){
+void FramesectionInputWidget::concreteRectColFS() {
+    QStringList concreteRectColFSHeadings;
+    QList<int> concreteRectColFSDataTypes;
+    this->framesectionType = "concrete rectangular column";
 
-        QJsonArray  jsonArray;
+    concreteRectColFSHeadings << tr("Name");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectColFSHeadings << tr("Material");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectColFSHeadings << tr("depth");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("width");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("longitudinal rebar material");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectColFSHeadings << tr("longitudinal rebar material corner");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectColFSHeadings << tr("longitudinal rebar num bars depth");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("longitudinal rebar num bars width");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("longitudinal rebar bar area");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("longitudinal rebar bar area corner");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("longitudinal rebar cover");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("transverse rebar material");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectColFSHeadings << tr("transverse rebar num bars depth");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("transverse rebar num bars width");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("transverse rebar bar area");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("transverse rebar spacing");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectColFSHeadings << tr("mass per length");
+    concreteRectColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteRectColFSHeadings;
+    this->dataTypes = concreteRectColFSDataTypes;
+}
+
+// same as concrete rectangular column framesection with
+// two field additions: flange thickness (double), web thickness (double)
+void FramesectionInputWidget::concreteBoxColFS() {
+    QStringList concreteBoxColFSHeadings;
+    QList<int> concreteBoxColFSDataTypes;
+    this->framesectionType = "concrete box column";
+
+    concreteBoxColFSHeadings << tr("Name");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBoxColFSHeadings << tr("Material");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBoxColFSHeadings << tr("depth");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("width");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("flange thickness");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("web thickness");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("longitudinal rebar material");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBoxColFSHeadings << tr("longitudinal rebar material corner");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBoxColFSHeadings << tr("longitudinal rebar num bars depth");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("longitudinal rebar num bars width");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("longitudinal rebar bar area");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("longitudinal rebar bar area corner");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("longitudinal rebar cover");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("transverse rebar material");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBoxColFSHeadings << tr("transverse rebar num bars depth");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("transverse rebar num bars width");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("transverse rebar bar area");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("transverse rebar spacing");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBoxColFSHeadings << tr("mass per length");
+    concreteBoxColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteBoxColFSHeadings;
+    this->dataTypes = concreteBoxColFSDataTypes;
+}
+
+void FramesectionInputWidget::concreteCircColFS() {
+    QStringList concreteCircColFSHeadings;
+    QList<int> concreteCircColFSDataTypes;
+    this->framesectionType = "concrete circular column";
+
+    concreteCircColFSHeadings << tr("Name");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCircColFSHeadings << tr("Material");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCircColFSHeadings << tr("diameter");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCircColFSHeadings << tr("longitudinal rebar material");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCircColFSHeadings << tr("longitudinal rebar num bars");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCircColFSHeadings << tr("longitudinal rebar bar area");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCircColFSHeadings << tr("longitudinal rebar cover");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCircColFSHeadings << tr("transverse rebar material");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCircColFSHeadings << tr("transverse rebar bar area");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCircColFSHeadings << tr("transverse rebar spacing");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCircColFSHeadings << tr("mass per length");
+    concreteCircColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteCircColFSHeadings;
+    this->dataTypes = concreteCircColFSDataTypes;
+}
+
+//same as concrete circular column + 1 field: wall thickness
+void FramesectionInputWidget::concretePipeColFS() {
+    QStringList concretePipeColFSHeadings;
+    QList<int> concretePipeColFSDataTypes;
+    this->framesectionType = "concrete pipe column";
+
+    concretePipeColFSHeadings << tr("Name");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concretePipeColFSHeadings << tr("Material");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concretePipeColFSHeadings << tr("diameter");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concretePipeColFSHeadings << tr("wall thickness");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concretePipeColFSHeadings << tr("longitudinal rebar material");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concretePipeColFSHeadings << tr("longitudinal rebar num bars");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concretePipeColFSHeadings << tr("longitudinal rebar bar area");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concretePipeColFSHeadings << tr("longitudinal rebar cover");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concretePipeColFSHeadings << tr("transverse rebar material");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QString;
+    concretePipeColFSHeadings << tr("transverse rebar bar area");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concretePipeColFSHeadings << tr("transverse rebar spacing");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concretePipeColFSHeadings << tr("mass per length");
+    concretePipeColFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concretePipeColFSHeadings;
+    this->dataTypes = concretePipeColFSDataTypes;
+}
+
+void
+FramesectionInputWidget::outputToJSON(QJsonObject &jsonObj){return;}
+
+
+void
+FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
         int numRows = theSpreadsheet->getNumRows();
 
+        // for each row of the spreadsheet
         for (int i=0; i<numRows; i++) {
             QJsonObject obj, lrebar, trebar;
+            // for each field defined in private member var tableHeader
+            // and the respective data type defined in private member var dataTypes
+            // (tableHeader and dataTypes defined in constructor function)
             for (int j=0; j<(this->tableHeader.size()); j++) {
                 QString fieldName = this->tableHeader[j].toLower();
-                if(this->dataTypes[j] == 0) {
-                    QString tmpString;
 
+                if(this->dataTypes[j] == 0) {
+                    //string
+                    QString tmpString;
                     if (theSpreadsheet->getString(i,j,tmpString) == false || tmpString.isEmpty()) {
                         qDebug() << "no value for " << fieldName << " in row " << i;
-                        break;
+                        return;
                     }
                     if (fieldName.startsWith("longitudinal rebar ") == true) {
-                        fieldName.remove(0,19);
-                        lrebar[fieldName] = tmpString;
+                        lrebar[fieldName.remove(0,19)] = tmpString;
                     } else if (fieldName.startsWith("transverse rebar ") == true) {
-                        fieldName.remove(0,17);
-                        trebar[fieldName] = tmpString;
+                        trebar[fieldName.remove(0,17)] = tmpString;
                     } else {
                         obj[fieldName] = tmpString;
                     }
-                }
-
-                if(this->dataTypes[j] == 1) {
+                } else if (this->dataTypes[j] == 1) {
+                    //double
                     double tmpDouble;
                     if (theSpreadsheet->getDouble(i,j,tmpDouble) == false) {
                         qDebug() << "no value for " << fieldName << " in row " << i;
-                        break;
+                        return;
                     }
                     if (fieldName.startsWith("longitudinal rebar ") == true) {
-                        fieldName.remove(0,19);
-                        lrebar[fieldName] = tmpDouble;
+                        lrebar[fieldName.remove(0,19)] = tmpDouble;
                     } else if (fieldName.startsWith("transverse rebar ") == true) {
-                        fieldName.remove(0,17);
-                        trebar[fieldName] = tmpDouble;
+                        trebar[fieldName.remove(0,17)] = tmpDouble;
                     } else {
                         obj[fieldName] = tmpDouble;
                     }
@@ -183,141 +288,53 @@ FramesectionInputWidget::outputToJSON(QJsonObject &jsonObj){
 
             obj["longitudinal rebar"] = lrebar;
             obj["transverse rebar"] = trebar;
+            obj["type"] = framesectionType;
             jsonArray.append(obj);
         }
-
-        // add the object
-        jsonObj["framesections"] = jsonArray;
 
 }
 
 void
-FramesectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
+FramesectionInputWidget::inputFromJSON(QJsonObject &jsonObject) { return; }
 
+void
+FramesectionInputWidget::inputFromJSON(QJsonArray &jsonArray){
     int currentRow = 0;
 
-    QString name, fs_type, fs_material, shape;
-    double depth, width, thickness, wlb, wlc, wlbp, tbp, wpd, tfw, tft, wt, bfw, bft, fr, cr;
-
-    // longitudinal rebar
-    QString lr_material, lr_materialCorner;
-    double lr_numBarsDepth, lr_numBarsWidth, lr_barArea, lr_barAreaCorner, lr_cover, lr_spacing;
-
-    // transverse rebar
-    QString tr_material;
-    double tr_numBarsDepth, tr_numBarsWidth, tr_numBarsThickness, tr_barArea, tr_barAreaCorner, tr_spacing, tr_cover;
-
-    //
-    // get the cline data (a json array) from the object, and for every
-    // object in the array, get the values and add to the spreadsheet
-    //
-
-    QJsonArray theArray = jsonObject["framesections"].toArray();
-    foreach (const QJsonValue &theValue, theArray) {
-        // get values
+    foreach (const QJsonValue &theValue, jsonArray) {
         QJsonObject theObject = theValue.toObject();
+        if (theObject["type"] == this->framesectionType) {
+            QJsonObject lrebar = theObject["longitudinal rebar"].toObject();
+            QJsonObject trebar = theObject["transverse rebar"].toObject();
 
-        name = theObject["name"].toString();
-        fs_type = theObject["type"].toString();
-        fs_material = theObject["material"].toString();
-        depth = theObject["depth"].toDouble();
-        width = theObject["width"].toDouble();
-        shape = theObject["shape"].toString();
+            for (int j=0; j<(this->tableHeader.size()); j++) {
+                QString fieldName = this->tableHeader[j].toLower();
 
-        thickness = theObject["thickness"].toDouble();
-        wlb = theObject["weld length brace"].toDouble();
-        wlc = theObject["weld length column"].toDouble();
-        wlbp = theObject["weld length baseplate"].toDouble();
-        tbp = theObject["thickness baseplate"].toDouble();
-        wpd = theObject["workpoint depth"].toDouble();
-        tfw = theObject["top flange width"].toDouble();
-        tft = theObject["top flange thickness"].toDouble();
-        wt = theObject["web thickness"].toDouble();
-        bfw = theObject["bottom flange width"].toDouble();
-        bft = theObject["bottom flange thickness"].toDouble();
-        fr = theObject["fillet radius"].toDouble();
-        cr = theObject["corner radius"].toDouble();
-
-        // longitudinal rebar
-        QJsonValue theLRValue = theObject["longitudinal rebar"];
-        QJsonObject lrObject = theLRValue.toObject();
-
-        lr_material = lrObject["material"].toString();
-        lr_materialCorner = lrObject["material corner"].toString();
-        lr_numBarsDepth = lrObject["num bars depth"].toDouble();
-        lr_numBarsWidth = lrObject["num bars width"].toDouble();
-        lr_barArea = lrObject["bar area"].toDouble();
-        lr_barAreaCorner = lrObject["bar area corner"].toDouble();
-        lr_cover = lrObject["lr_cover"].toDouble();
-        lr_spacing = lrObject["lr_spacing"].toDouble();
-
-        //********* FINISH THIS
-
-
-
-        // transverse rebar
-        QJsonValue theTRValue = theObject["transverse rebar"];
-        QJsonObject trObject = theTRValue.toObject();
-
-        tr_material = trObject["material"].toString();
-        tr_numBarsDepth = trObject["num bars depth"].toDouble();
-        tr_numBarsWidth = trObject["num bars width"].toDouble();
-        tr_numBarsThickness  = trObject["num bars thickness"].toDouble();
-        tr_barArea = trObject["bar area"].toDouble();
-        tr_barAreaCorner = trObject["bar area corner"].toDouble();
-        tr_spacing = trObject["spacing"].toDouble();
-        tr_cover = trObject["cover"].toDouble();
-
-
-        // add to the spreadsheet
-        theSpreadsheet->setString(currentRow, 0, name);
-        theSpreadsheet->setString(currentRow, 1, fs_type);
-        theSpreadsheet->setString(currentRow, 2, fs_material);
-
-        theSpreadsheet->setDouble(currentRow, 3, depth);
-        theSpreadsheet->setDouble(currentRow, 4, width);
-        theSpreadsheet->setString(currentRow, 5, shape);
-
-        theSpreadsheet->setDouble(currentRow, 6, thickness);
-        theSpreadsheet->setDouble(currentRow, 7, wlb);
-        theSpreadsheet->setDouble(currentRow, 8, wlc);
-        theSpreadsheet->setDouble(currentRow, 9, wlbp);
-        theSpreadsheet->setDouble(currentRow, 10, tbp);
-        theSpreadsheet->setDouble(currentRow, 11, wpd);
-        theSpreadsheet->setDouble(currentRow, 12, tfw);
-        theSpreadsheet->setDouble(currentRow, 13, tft);
-        theSpreadsheet->setDouble(currentRow, 14, wt);
-        theSpreadsheet->setDouble(currentRow, 15, bfw);
-        theSpreadsheet->setDouble(currentRow, 16, bft);
-        theSpreadsheet->setDouble(currentRow, 17, fr);
-        theSpreadsheet->setDouble(currentRow, 18, cr);
-
-
-        // add longitudinal rebar to the spreadsheet
-        theSpreadsheet->setString(currentRow, 19, lr_material);
-        theSpreadsheet->setString(currentRow, 20, lr_materialCorner);
-        theSpreadsheet->setDouble(currentRow, 21, lr_numBarsDepth);
-        theSpreadsheet->setDouble(currentRow, 21, lr_numBarsWidth);
-        theSpreadsheet->setDouble(currentRow, 23, lr_numBarsDepth);
-        theSpreadsheet->setDouble(currentRow, 24, lr_barArea);
-        theSpreadsheet->setDouble(currentRow, 25, lr_spacing);
-        theSpreadsheet->setDouble(currentRow, 26, lr_cover);
-
-        // add transverse rebar to the spreadsheet
-
-        theSpreadsheet->setString(currentRow, 27, tr_material);
-        theSpreadsheet->setDouble(currentRow, 28, tr_numBarsDepth);
-        theSpreadsheet->setDouble(currentRow, 29, tr_numBarsWidth);
-        theSpreadsheet->setDouble(currentRow, 30, tr_numBarsThickness);
-        theSpreadsheet->setDouble(currentRow, 31, tr_barArea);
-        theSpreadsheet->setDouble(currentRow, 32, tr_barAreaCorner);
-        theSpreadsheet->setDouble(currentRow, 33, tr_spacing);
-        theSpreadsheet->setDouble(currentRow, 34, tr_cover);
-
-
-        currentRow++;
+                if(this->dataTypes[j] == 0) {
+                    QString tmpString;
+                    if(fieldName.startsWith("longitudinal rebar ") == true) {
+                        tmpString = lrebar[fieldName.remove(0,19)].toString();
+                    } else if (fieldName.startsWith("transverse rebar ") == true) {
+                        tmpString = trebar[fieldName.remove(0,17)].toString();
+                    } else {
+                        tmpString = theObject[fieldName].toString();
+                    }
+                    theSpreadsheet->setString(currentRow, j, tmpString);
+                } else if (this->dataTypes[j] == 1) {
+                    double tmpDouble;
+                    if(fieldName.startsWith("longitudinal rebar ") == true) {
+                        tmpDouble = lrebar[fieldName.remove(0,19)].toDouble();
+                    } else if (fieldName.startsWith("transverse rebar ") == true) {
+                        tmpDouble = trebar[fieldName.remove(0,17)].toDouble();
+                    } else {
+                        tmpDouble = theObject[fieldName].toDouble();
+                    }
+                    theSpreadsheet->setDouble(currentRow, j, tmpDouble);
+                }
+            }
+            currentRow++;
+        }
     }
-
 }
 
 

--- a/InputSheetBM/FramesectionInputWidget.cpp
+++ b/InputSheetBM/FramesectionInputWidget.cpp
@@ -52,6 +52,22 @@ FramesectionInputWidget::FramesectionInputWidget(QString framesectionType, SimCe
     if (framesectionType == "concrete circular column") { this->concreteCircColFS(); }
     if (framesectionType == "concrete pipe column") { this->concretePipeColFS(); }
     if (framesectionType == "concrete rectangular beam") { this->concreteRectBeamFS(); }
+    if (framesectionType == "concrete tee beam") { this->concreteTeeBeamFS(); }
+    if (framesectionType == "concrete l beam") { this->concreteTeeBeamFS(); this->framesectionType = "concrete l beam"; }
+    if (framesectionType == "concrete cross beam") { this->concreteCrossBeamFS(); }
+    if (framesectionType == "steel wide flange") { this->steelWideFlangeFS(); }
+    if (framesectionType == "steel channel") { this->steelChannelFS(); }
+    if (framesectionType == "steel double channel") { this->steelDoubleChannelFS(); }
+    if (framesectionType == "steel tee") { this->steelChannelFS(); this->framesectionType = "steel tee"; }
+    if (framesectionType == "steel angle") { this->steelChannelFS(); this->framesectionType = "steel angle"; }
+    if (framesectionType == "steel double angle") { this->steelDoubleAngleFS(); }
+    if (framesectionType == "steel tube") { this->steelTubeFS(); }
+    if (framesectionType == "filled steel tube") { this->filledSteelTubeFS(); }
+    if (framesectionType == "steel pipe") { this->steelPipeFS(); }
+    if (framesectionType == "filled steel pipe") { this->filledSteelPipeFS(); }
+    if (framesectionType == "steel plate") { this->steelPlateFS(); }
+    if (framesectionType == "steel rod") { this->steelRodFS(); }
+    if (framesectionType == "buckling restrained brace") { this->bucklingRestrainedBraceFS(); }
 
     this->setupSpreadsheet();
 }
@@ -103,6 +119,7 @@ FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
                     QString tmpString;
                     if (theSpreadsheet->getString(i,j,tmpString) == false || tmpString.isEmpty()) {
                         qDebug() << "no value for " << fieldName << " in row " << i;
+                        // TODO: need to actually break out of this loop
                         return;
                     }
                     if (fieldName.startsWith("longitudinal rebar ") == true) {
@@ -117,6 +134,7 @@ FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
                     double tmpDouble;
                     if (theSpreadsheet->getDouble(i,j,tmpDouble) == false) {
                         qDebug() << "no value for " << fieldName << " in row " << i;
+                        // TODO: need to actually break out of this loop
                         return;
                     }
                     if (fieldName.startsWith("longitudinal rebar ") == true) {
@@ -387,4 +405,386 @@ void FramesectionInputWidget::concreteRectBeamFS() {
 
     this->tableHeader = concreteRectBeamFSHeadings;
     this->dataTypes = concreteRectBeamFSDataTypes;
+}
+
+void FramesectionInputWidget::concreteTeeBeamFS() {
+    QStringList concreteTeeBeamFSHeadings;
+    QList<int> concreteTeeBeamFSDataTypes;
+    this->framesectionType = "concrete tee beam";
+
+    concreteTeeBeamFSHeadings << tr("Name");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteTeeBeamFSHeadings << tr("Material");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteTeeBeamFSHeadings << tr("depth");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("width");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("flange thickness");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("web thickness at flange");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("web thickness at tip");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar material top");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar material bottom");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar num bars top");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar num bars bottom");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar bar area top");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar bar area bottom");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar cover top");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("longitudinal rebar cover bottom");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("transverse rebar material");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("transverse rebar bar area");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("transverse rebar spacing");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteTeeBeamFSHeadings << tr("mass per length");
+    concreteTeeBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteTeeBeamFSHeadings;
+    this->dataTypes = concreteTeeBeamFSDataTypes;
+}
+
+void FramesectionInputWidget::concreteCrossBeamFS() {
+    QStringList concreteCrossBeamFSHeadings;
+    QList<int> concreteCrossBeamFSDataTypes;
+    this->framesectionType = "concrete cross beam";
+
+    concreteCrossBeamFSHeadings << tr("Name");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCrossBeamFSHeadings << tr("Material");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCrossBeamFSHeadings << tr("depth");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("width");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("flange thickness");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("web thickness");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("longitudinal rebar material center");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCrossBeamFSHeadings << tr("longitudinal rebar material tip");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteCrossBeamFSHeadings << tr("longitudinal rebar num bars center");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("longitudinal rebar num bars tip");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("longitudinal rebar bar area center");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("longitudinal rebar bar area tip");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("longitudinal rebar cover");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("transverse rebar material");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("transverse rebar bar area");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("transverse rebar spacing");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteCrossBeamFSHeadings << tr("mass per length");
+    concreteCrossBeamFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteCrossBeamFSHeadings;
+    this->dataTypes = concreteCrossBeamFSDataTypes;
+}
+
+void FramesectionInputWidget::steelWideFlangeFS() {
+    QStringList steelWideFlangeFSHeadings;
+    QList<int> steelWideFlangeFSDataTypes;
+    this->framesectionType = "steel wide flange";
+
+    steelWideFlangeFSHeadings << tr("Name");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelWideFlangeFSHeadings << tr("database");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelWideFlangeFSHeadings << tr("shape");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelWideFlangeFSHeadings << tr("material");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelWideFlangeFSHeadings << tr("depth");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelWideFlangeFSHeadings << tr("top flange width");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelWideFlangeFSHeadings << tr("top flange thickness");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelWideFlangeFSHeadings << tr("web thickness");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelWideFlangeFSHeadings << tr("bottom flange width");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelWideFlangeFSHeadings << tr("bottom flange thickness");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelWideFlangeFSHeadings << tr("fillet radius");
+    steelWideFlangeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelWideFlangeFSHeadings;
+    this->dataTypes = steelWideFlangeFSDataTypes;
+}
+
+void FramesectionInputWidget::steelChannelFS() {
+    QStringList steelChannelFSHeadings;
+    QList<int> steelChannelFSDataTypes;
+    this->framesectionType = "steel channel";
+
+    steelChannelFSHeadings << tr("Name");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelChannelFSHeadings << tr("database");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelChannelFSHeadings << tr("shape");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelChannelFSHeadings << tr("material");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelChannelFSHeadings << tr("depth");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelChannelFSHeadings << tr("width");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelChannelFSHeadings << tr("flange thickness");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelChannelFSHeadings << tr("web thickness");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelChannelFSHeadings << tr("fillet radius");
+    steelChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelChannelFSHeadings;
+    this->dataTypes = steelChannelFSDataTypes;
+}
+
+void FramesectionInputWidget::steelDoubleChannelFS() {
+    QStringList steelDoubleChannelFSHeadings;
+    QList<int> steelDoubleChannelFSDataTypes;
+    this->framesectionType = "steel double channel";
+
+    steelDoubleChannelFSHeadings << tr("Name");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleChannelFSHeadings << tr("database");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleChannelFSHeadings << tr("shape");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleChannelFSHeadings << tr("material");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleChannelFSHeadings << tr("depth");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleChannelFSHeadings << tr("width of single channel");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleChannelFSHeadings << tr("flange thickness");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleChannelFSHeadings << tr("web thickness");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleChannelFSHeadings << tr("back to back distance");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleChannelFSHeadings << tr("fillet radius");
+    steelDoubleChannelFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelDoubleChannelFSHeadings;
+    this->dataTypes = steelDoubleChannelFSDataTypes;
+}
+
+void FramesectionInputWidget::steelDoubleAngleFS() {
+    QStringList steelDoubleAngleFSHeadings;
+    QList<int> steelDoubleAngleFSDataTypes;
+    this->framesectionType = "steel double angle";
+
+    steelDoubleAngleFSHeadings << tr("Name");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleAngleFSHeadings << tr("database");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleAngleFSHeadings << tr("shape");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleAngleFSHeadings << tr("material");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelDoubleAngleFSHeadings << tr("depth");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleAngleFSHeadings << tr("width of single angle");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleAngleFSHeadings << tr("flange thickness");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleAngleFSHeadings << tr("web thickness");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleAngleFSHeadings << tr("back to back distance");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelDoubleAngleFSHeadings << tr("fillet radius");
+    steelDoubleAngleFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelDoubleAngleFSHeadings;
+    this->dataTypes = steelDoubleAngleFSDataTypes;
+}
+
+void FramesectionInputWidget::steelTubeFS() {
+    QStringList steelTubeFSHeadings;
+    QList<int> steelTubeFSDataTypes;
+    this->framesectionType = "steel tube";
+
+    steelTubeFSHeadings << tr("Name");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelTubeFSHeadings << tr("database");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelTubeFSHeadings << tr("shape");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelTubeFSHeadings << tr("material");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelTubeFSHeadings << tr("depth");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelTubeFSHeadings << tr("width");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelTubeFSHeadings << tr("flange thickness");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelTubeFSHeadings << tr("web thickness");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelTubeFSHeadings << tr("corner radius");
+    steelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelTubeFSHeadings;
+    this->dataTypes = steelTubeFSDataTypes;
+}
+
+void FramesectionInputWidget::filledSteelTubeFS() {
+    QStringList filledSteelTubeFSHeadings;
+    QList<int> filledSteelTubeFSDataTypes;
+    this->framesectionType = "filled steel tube";
+
+    filledSteelTubeFSHeadings << tr("Name");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelTubeFSHeadings << tr("database");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelTubeFSHeadings << tr("shape");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelTubeFSHeadings << tr("material");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelTubeFSHeadings << tr("material fill");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelTubeFSHeadings << tr("depth");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    filledSteelTubeFSHeadings << tr("width");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    filledSteelTubeFSHeadings << tr("flange thickness");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    filledSteelTubeFSHeadings << tr("web thickness");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    filledSteelTubeFSHeadings << tr("corner radius");
+    filledSteelTubeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = filledSteelTubeFSHeadings;
+    this->dataTypes = filledSteelTubeFSDataTypes;
+}
+
+void FramesectionInputWidget::steelPipeFS() {
+    QStringList steelPipeFSHeadings;
+    QList<int> steelPipeFSDataTypes;
+    this->framesectionType = "steel pipe";
+
+    steelPipeFSHeadings << tr("Name");
+    steelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelPipeFSHeadings << tr("database");
+    steelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelPipeFSHeadings << tr("shape");
+    steelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelPipeFSHeadings << tr("material");
+    steelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelPipeFSHeadings << tr("diameter");
+    steelPipeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelPipeFSHeadings << tr("wall thickness");
+    steelPipeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelPipeFSHeadings;
+    this->dataTypes = steelPipeFSDataTypes;
+}
+
+void FramesectionInputWidget::filledSteelPipeFS() {
+    QStringList filledSteelPipeFSHeadings;
+    QList<int> filledSteelPipeFSDataTypes;
+    this->framesectionType = "filled steel pipe";
+
+    filledSteelPipeFSHeadings << tr("Name");
+    filledSteelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelPipeFSHeadings << tr("database");
+    filledSteelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelPipeFSHeadings << tr("shape");
+    filledSteelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelPipeFSHeadings << tr("material");
+    filledSteelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelPipeFSHeadings << tr("material fill");
+    filledSteelPipeFSDataTypes << SIMPLESPREADSHEET_QString;
+    filledSteelPipeFSHeadings << tr("diameter");
+    filledSteelPipeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    filledSteelPipeFSHeadings << tr("wall thickness");
+    filledSteelPipeFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = filledSteelPipeFSHeadings;
+    this->dataTypes = filledSteelPipeFSDataTypes;
+}
+
+void FramesectionInputWidget::steelPlateFS() {
+    QStringList steelPlateFSHeadings;
+    QList<int> steelPlateFSDataTypes;
+    this->framesectionType = "steel plate";
+
+    steelPlateFSHeadings << tr("Name");
+    steelPlateFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelPlateFSHeadings << tr("material");
+    steelPlateFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelPlateFSHeadings << tr("depth");
+    steelPlateFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    steelPlateFSHeadings << tr("width");
+    steelPlateFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelPlateFSHeadings;
+    this->dataTypes = steelPlateFSDataTypes;
+}
+
+void FramesectionInputWidget::steelRodFS() {
+    QStringList steelRodFSHeadings;
+    QList<int> steelRodFSDataTypes;
+    this->framesectionType = "steel rod";
+
+    steelRodFSHeadings << tr("Name");
+    steelRodFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelRodFSHeadings << tr("material");
+    steelRodFSDataTypes << SIMPLESPREADSHEET_QString;
+    steelRodFSHeadings << tr("diameter");
+    steelRodFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = steelRodFSHeadings;
+    this->dataTypes = steelRodFSDataTypes;
+}
+
+void FramesectionInputWidget::bucklingRestrainedBraceFS() {
+    QStringList bucklingBraceFSHeadings;
+    QList<int> bucklingBraceFSDataTypes;
+    this->framesectionType = "buckling restrained brace";
+
+    bucklingBraceFSHeadings << tr("Name");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QString;
+    bucklingBraceFSHeadings << tr("database");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QString;
+    bucklingBraceFSHeadings << tr("shape");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QString;
+    bucklingBraceFSHeadings << tr("material");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QString;
+    bucklingBraceFSHeadings << tr("material core");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QString;
+    bucklingBraceFSHeadings << tr("depth");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    bucklingBraceFSHeadings << tr("width");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    bucklingBraceFSHeadings << tr("area core");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    bucklingBraceFSHeadings << tr("yield length");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    bucklingBraceFSHeadings << tr("omega");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QDouble;
+    bucklingBraceFSHeadings << tr("beta-omega");
+    bucklingBraceFSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = bucklingBraceFSHeadings;
+    this->dataTypes = bucklingBraceFSDataTypes;
 }

--- a/InputSheetBM/FramesectionInputWidget.cpp
+++ b/InputSheetBM/FramesectionInputWidget.cpp
@@ -351,6 +351,7 @@ FramesectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
         lr_barArea = lrObject["bar area"].toDouble();
         lr_barAreaCorner = lrObject["bar area corner"].toDouble();
         lr_cover = lrObject["lr_cover"].toDouble();
+        lr_spacing = lrObject["lr_spacing"].toDouble();
 
         //********* FINISH THIS
 

--- a/InputSheetBM/FramesectionInputWidget.cpp
+++ b/InputSheetBM/FramesectionInputWidget.cpp
@@ -98,11 +98,11 @@ FramesectionInputWidget::setupSpreadsheet() {
     this->setMinimumWidth(500);
 }
 
-void
-FramesectionInputWidget::outputToJSON(QJsonObject &jsonObj){return;}
+bool
+FramesectionInputWidget::outputToJSON(QJsonObject &jsonObj){return(true);}
 
 
-void
+bool
 FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
         int numRows = theSpreadsheet->getNumRows();
 
@@ -121,7 +121,7 @@ FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
                     if (theSpreadsheet->getString(i,j,tmpString) == false || tmpString.isEmpty()) {
                         qDebug() << "no value for " << fieldName << " in row " << i;
                         // TODO: need to actually break out of this loop
-                        return;
+                        return(true);
                     }
                     if (fieldName.startsWith("longitudinal rebar ") == true) {
                         lrebar[fieldName.remove(0,19)] = tmpString;
@@ -136,7 +136,7 @@ FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
                     if (theSpreadsheet->getDouble(i,j,tmpDouble) == false) {
                         qDebug() << "no value for " << fieldName << " in row " << i;
                         // TODO: need to actually break out of this loop
-                        return;
+                        return(true);
                     }
                     if (fieldName.startsWith("longitudinal rebar ") == true) {
                         lrebar[fieldName.remove(0,19)] = tmpDouble;
@@ -154,15 +154,16 @@ FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
             jsonArray.append(obj);
         }
 
+        return(true);
+
 }
 
-void
-FramesectionInputWidget::inputFromJSON(QJsonObject &jsonObject) { return; }
+bool
+FramesectionInputWidget::inputFromJSON(QJsonObject &jsonObject) { return(true); }
 
-void
+bool
 FramesectionInputWidget::inputFromJSON(QJsonArray &jsonArray){
     int currentRow = 0;
-
     foreach (const QJsonValue &theValue, jsonArray) {
         QJsonObject theObject = theValue.toObject();
         if (theObject["type"] == framesectionType) {
@@ -197,6 +198,7 @@ FramesectionInputWidget::inputFromJSON(QJsonArray &jsonArray){
             currentRow++;
         }
     }
+    return(true);
 }
 
 void

--- a/InputSheetBM/FramesectionInputWidget.cpp
+++ b/InputSheetBM/FramesectionInputWidget.cpp
@@ -50,80 +50,77 @@ FramesectionInputWidget::FramesectionInputWidget(SimCenterWidget *parent) : SimC
     QStringList headings;
     QList<int> dataTypes;
     headings << tr("Name");
+    dataTypes << SIMPLESPREADSHEET_QString;
     headings << tr("Type");
+    dataTypes << SIMPLESPREADSHEET_QString;
     headings << tr("Material");
+    dataTypes << SIMPLESPREADSHEET_QString;
 
     headings << tr("Depth");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("Width");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("Shape");
+    dataTypes << SIMPLESPREADSHEET_QString;
 
     headings << tr("thickness");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("weld length brace");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("weld length column");
+    dataTypes << SIMPLESPREADSHEET_QString;
     headings << tr("weld length baseplate");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("thickness baseplate");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("workpoint depth");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("top flange width");
+    dataTypes << SIMPLESPREADSHEET_QString;
     headings << tr("top flange thickness");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("web thickness");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("bottom flange width");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("bottom flange thickness");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("fillet radius");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("corner radius");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
 
     headings << tr("longitudinal rebar material");
+    dataTypes << SIMPLESPREADSHEET_QString;
     headings << tr("longitudinal rebar material corner");
+    dataTypes << SIMPLESPREADSHEET_QString;
     headings << tr("longitudinal rebar num bars depth");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("longitudinal rebar num bars width");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("longitudinal rebar bar area");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("longitudinal rebar bar area corner");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("longitudinal rebar cover");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
 
     headings << tr("transverse rebar material");
+    dataTypes << SIMPLESPREADSHEET_QString;
     headings << tr("transverse rebar num bars depth");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("transverse rebar num bars width");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("transverse rebar num bars thickness");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("transverse rebar bar area");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("transverse rebar spacing");
+    dataTypes << SIMPLESPREADSHEET_QDouble;
     headings << tr("transverse rebar cover");
-
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QString;
-
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QString;
-
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
     dataTypes << SIMPLESPREADSHEET_QDouble;
 
-    // longitudinal rebar
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    // transverse rebar
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-
-    theSpreadsheet = new SpreadsheetWidget(28, 1000, headings, dataTypes, this);
+    theSpreadsheet = new SpreadsheetWidget(headings.size(), 1000, headings, dataTypes, this);
 
     theLayout->addWidget(theSpreadsheet);
 
@@ -203,33 +200,33 @@ FramesectionInputWidget::outputToJSON(QJsonObject &jsonObj){
                 break;
             if (theSpreadsheet->getString(i,20,lr_materialCorner) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,12,lr_numBarsDepth) == false)
+            if (theSpreadsheet->getDouble(i,21,lr_numBarsDepth) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,13,lr_numBarsWidth) == false)
+            if (theSpreadsheet->getDouble(i,22,lr_numBarsWidth) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,14,lr_barArea) == false)
+            if (theSpreadsheet->getDouble(i,23,lr_barArea) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,15,lr_barAreaCorner) == false)
+            if (theSpreadsheet->getDouble(i,24,lr_barAreaCorner) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,16,lr_cover) == false)
+            if (theSpreadsheet->getDouble(i,25,lr_cover) == false)
                 break;
 
             // transverse rebar
-            if (theSpreadsheet->getString(i,00,tr_material) == false)
+            if (theSpreadsheet->getString(i,26,tr_material) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,00,tr_numBarsDepth) == false)
+            if (theSpreadsheet->getDouble(i,27,tr_numBarsDepth) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,00,tr_numBarsWidth) == false)
+            if (theSpreadsheet->getDouble(i,28,tr_numBarsWidth) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,00,tr_numBarsThickness) == false)
+            if (theSpreadsheet->getDouble(i,29,tr_numBarsThickness) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,00,tr_barArea) == false)
+            if (theSpreadsheet->getDouble(i,30,tr_barArea) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,00,tr_barAreaCorner) == false)
+//            if (theSpreadsheet->getDouble(i,31,tr_barAreaCorner) == false)
+//                break;
+            if (theSpreadsheet->getDouble(i,31,tr_spacing) == false)
                 break;
-            if (theSpreadsheet->getDouble(i,00,tr_spacing) == false)
-                break;
-            if (theSpreadsheet->getDouble(i,00,tr_cover) == false)
+            if (theSpreadsheet->getDouble(i,32,tr_cover) == false)
                 break;
 
 
@@ -260,21 +257,22 @@ FramesectionInputWidget::outputToJSON(QJsonObject &jsonObj){
             // longitudinal rebar   -FIX THIS!!!!!!! todo
             QJsonObject lrebar;
 
-            lrebar["material"]=tr_material;
+            lrebar["material"]=lr_material;
             lrebar["material corner"]=lr_materialCorner;
             lrebar["num bars depth"]=lr_numBarsDepth;
             lrebar["num bars width"]=lr_numBarsWidth;
             lrebar["bar area"]=lr_barArea;
             lrebar["bar area corner"]=lr_barAreaCorner;
+            lrebar["cover"]=lr_cover;
 
-            lrebar["longitudinal rebar"] = lrebar;
+            obj["longitudinal rebar"] = lrebar;
 
             // transverse rebar
             QJsonObject trebar;
 
             trebar["material"]=tr_material;
             trebar["bar area"]=tr_barArea;
-            trebar["bar area corner"]=tr_barAreaCorner;
+//            trebar["bar area corner"]=tr_barAreaCorner;
             trebar["spacing"]=tr_spacing;
             trebar["cover"]=tr_cover;
             trebar["num bars depth"]=tr_numBarsDepth;

--- a/InputSheetBM/FramesectionInputWidget.cpp
+++ b/InputSheetBM/FramesectionInputWidget.cpp
@@ -89,7 +89,8 @@ FramesectionInputWidget::~FramesectionInputWidget()
 
 }
 
-void FramesectionInputWidget::setupSpreadsheet() {
+void
+FramesectionInputWidget::setupSpreadsheet() {
     theLayout = new QHBoxLayout();
     this->setLayout(theLayout);
     theSpreadsheet = new SpreadsheetWidget(tableHeader.size(), 1000, tableHeader, dataTypes, this);
@@ -147,8 +148,8 @@ FramesectionInputWidget::outputToJSON(QJsonArray &jsonArray){
                 }
             }
 
-            obj["longitudinal rebar"] = lrebar;
-            obj["transverse rebar"] = trebar;
+            if (!lrebar.isEmpty()) { obj["longitudinal rebar"] = lrebar; }
+            if (!trebar.isEmpty()) { obj["transverse rebar"] = trebar; }
             obj["type"] = framesectionType;
             jsonArray.append(obj);
         }

--- a/InputSheetBM/FramesectionInputWidget.h
+++ b/InputSheetBM/FramesectionInputWidget.h
@@ -71,11 +71,12 @@ private:
     QList<int> dataTypes;
     QString framesectionType;
 
+    void setupSpreadsheet();
     void concreteRectColFS();
     void concreteBoxColFS();
     void concreteCircColFS();
     void concretePipeColFS();
-
+    void concreteRectBeamFS();
 };
 
 #endif // FRAMESECTIONINPUWIDGET_H

--- a/InputSheetBM/FramesectionInputWidget.h
+++ b/InputSheetBM/FramesectionInputWidget.h
@@ -77,6 +77,19 @@ private:
     void concreteCircColFS();
     void concretePipeColFS();
     void concreteRectBeamFS();
+    void concreteTeeBeamFS();
+    void concreteCrossBeamFS();
+    void steelWideFlangeFS();
+    void steelChannelFS();
+    void steelDoubleChannelFS();
+    void steelDoubleAngleFS();
+    void steelTubeFS();
+    void filledSteelTubeFS();
+    void steelPipeFS();
+    void filledSteelPipeFS();
+    void steelPlateFS();
+    void steelRodFS();
+    void bucklingRestrainedBraceFS();
 };
 
 #endif // FRAMESECTIONINPUWIDGET_H

--- a/InputSheetBM/FramesectionInputWidget.h
+++ b/InputSheetBM/FramesectionInputWidget.h
@@ -51,10 +51,14 @@ class FramesectionInputWidget : public SimCenterTableWidget
 public:
 
     explicit FramesectionInputWidget(SimCenterWidget *parent = 0);
+    explicit FramesectionInputWidget(QString framesectionType, SimCenterWidget *parent = 0);
+    explicit FramesectionInputWidget(QStringList headings, QList<int> dataTypes, QString framesectionType, SimCenterWidget *parent = 0);
     ~FramesectionInputWidget();
 
     void outputToJSON(QJsonObject &rvObject);
+    void outputToJSON(QJsonArray &rvObject);
     void inputFromJSON(QJsonObject &rvObject);
+    void inputFromJSON(QJsonArray &rvObject);
     void clear(void);
 
 signals:
@@ -65,6 +69,12 @@ private:
     QHBoxLayout *theLayout;
     QStringList   tableHeader;
     QList<int> dataTypes;
+    QString framesectionType;
+
+    void concreteRectColFS();
+    void concreteBoxColFS();
+    void concreteCircColFS();
+    void concretePipeColFS();
 
 };
 

--- a/InputSheetBM/FramesectionInputWidget.h
+++ b/InputSheetBM/FramesectionInputWidget.h
@@ -55,10 +55,10 @@ public:
     explicit FramesectionInputWidget(QStringList headings, QList<int> dataTypes, QString framesectionType, SimCenterWidget *parent = 0);
     ~FramesectionInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void outputToJSON(QJsonArray &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonArray &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonArray &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonArray &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/FramesectionInputWidget.h
+++ b/InputSheetBM/FramesectionInputWidget.h
@@ -64,7 +64,7 @@ public slots:
 private:
     QHBoxLayout *theLayout;
     QStringList   tableHeader;
-
+    QList<int> dataTypes;
 
 };
 

--- a/InputSheetBM/GeneralInformationWidget.cpp
+++ b/InputSheetBM/GeneralInformationWidget.cpp
@@ -160,7 +160,7 @@ GeneralInformationWidget::~GeneralInformationWidget()
 
 }
 
-void
+bool
 GeneralInformationWidget::outputToJSON(QJsonObject &jsonObj){
 
     jsonObj["name"] = nameEdit->text().trimmed();
@@ -199,9 +199,11 @@ GeneralInformationWidget::outputToJSON(QJsonObject &jsonObj){
 
     jsonObj["units"] = units;
 
+    return(true);
+
 }
 
-void
+bool
 GeneralInformationWidget::inputFromJSON(QJsonObject &jsonObject){
 
     double rev;
@@ -255,6 +257,7 @@ GeneralInformationWidget::inputFromJSON(QJsonObject &jsonObject){
     QJsonValue unitsTempValue = unitsObj["temperature"];
     unitsTemperatureEdit->setText(unitsTempValue.toString());
 
+    return(true);
 }
 
 void

--- a/InputSheetBM/GeneralInformationWidget.h
+++ b/InputSheetBM/GeneralInformationWidget.h
@@ -53,10 +53,10 @@ public:
     explicit GeneralInformationWidget(QWidget *parent = 0);
     ~GeneralInformationWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
-    void outputToJSON(QJsonArray &arrayObject);
-    void inputFromJSON(QJsonArray &arrayObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonArray &arrayObject);
+    bool inputFromJSON(QJsonArray &arrayObject);
 
     void clear(void);
 

--- a/InputSheetBM/InputWidgetSheetBM.cpp
+++ b/InputSheetBM/InputWidgetSheetBM.cpp
@@ -112,7 +112,7 @@ InputWidgetSheetBM::InputWidgetSheetBM(QWidget *parent) : QWidget(parent), curre
         "Concrete Circular Column", "Concrete Pipe Column",
         "Concrete Rectangular Beam", "Concrete Tee Beam",
         "Concrete L Beam", "Concrete Cross Beam", "Steel Wide Flange",
-        "Steel Channel", "Steep Double Channel", "Steel Tee",
+        "Steel Channel", "Steel Double Channel", "Steel Tee",
         "Steel Angle", "Steel Double Angle", "Steel Tube",
         "Filled Steel Tube", "Steel Pipe", "Filled Steel Pipe",
         "Steel Plate", "Steel Rod", "Buckling Restrained Brace"

--- a/InputSheetBM/InputWidgetSheetBM.cpp
+++ b/InputSheetBM/InputWidgetSheetBM.cpp
@@ -119,6 +119,7 @@ InputWidgetSheetBM::InputWidgetSheetBM(QWidget *parent) : QWidget(parent), curre
         }));
   for (int i=0; i<framesectionTypes.size(); i++) {
       framesectionsItem->appendRow(new QStandardItem(framesectionTypes[i]));
+      theFramesectionTypes << framesectionTypes[i].toLower();
   }
 
   propertiesItem->appendRow(new QStandardItem("Slabsections"));
@@ -154,10 +155,9 @@ InputWidgetSheetBM::InputWidgetSheetBM(QWidget *parent) : QWidget(parent), curre
   theColumnInput = new ColumnInputWidget();
   theSteelInput = new SteelInputWidget();
   theConcreteInput = new ConcreteInputWidget();
-  theConcreteRectColFSInput = new FramesectionInputWidget("concrete rectangular column");
-  theConcreteBoxColFSInput = new FramesectionInputWidget("concrete box column");
-  theConcreteCircColFSInput = new FramesectionInputWidget("concrete circular column");
-  theConcretePipeColFSInput = new FramesectionInputWidget("concrete pipe column");
+  for (int i=0; i<theFramesectionTypes.size(); i++) {
+      theFramesectionInputs[theFramesectionTypes[i]] = new FramesectionInputWidget(theFramesectionTypes[i]);
+  }
   theSlabsectionInput = new SlabsectionInputWidget();
   theWallsectionInput = new WallsectionInputWidget();
   theConnectionInput = new ConnectionInputWidget();
@@ -238,18 +238,9 @@ void InputWidgetSheetBM::selectionChangedSlot(const QItemSelection & /*newSelect
     } else if (selectedText == tr("Concrete")) {
         horizontalLayout->insertWidget(horizontalLayout->count()-1, theConcreteInput, 1);
         currentWidget = theConcreteInput;
-    } else if (selectedText == tr("Concrete Rectangular Column")) {
-        horizontalLayout->insertWidget(horizontalLayout->count()-1, theConcreteRectColFSInput, 1);
-        currentWidget = theConcreteRectColFSInput;
-    } else if (selectedText == tr("Concrete Box Column")) {
-        horizontalLayout->insertWidget(horizontalLayout->count()-1, theConcreteBoxColFSInput, 1);
-        currentWidget = theConcreteBoxColFSInput;
-    } else if (selectedText == tr("Concrete Circular Column")) {
-        horizontalLayout->insertWidget(horizontalLayout->count()-1, theConcreteCircColFSInput, 1);
-        currentWidget = theConcreteCircColFSInput;
-    } else if (selectedText == tr("Concrete Pipe Column")) {
-        horizontalLayout->insertWidget(horizontalLayout->count()-1, theConcretePipeColFSInput, 1);
-        currentWidget = theConcretePipeColFSInput;
+    } else if (theFramesectionTypes.contains(selectedText.toLower())) {
+        horizontalLayout->insertWidget(horizontalLayout->count()-1, theFramesectionInputs[selectedText.toLower()], 1);
+        currentWidget = theFramesectionInputs[selectedText.toLower()];
     } else if (selectedText == tr("Slabsections")) {
         horizontalLayout->insertWidget(horizontalLayout->count()-1, theSlabsectionInput, 1);
         currentWidget = theSlabsectionInput;
@@ -307,10 +298,9 @@ InputWidgetSheetBM::outputToJSON(QJsonObject &jsonObjectTop)
     QJsonArray theFramesectionsArray;
     jsonObjProperties["framesections"]=theFramesectionsArray;
 
-    theConcreteRectColFSInput->outputToJSON(theFramesectionsArray);
-    theConcreteBoxColFSInput->outputToJSON(theFramesectionsArray);
-    theConcreteCircColFSInput->outputToJSON(theFramesectionsArray);
-    theConcretePipeColFSInput->outputToJSON(theFramesectionsArray);
+    for (int i=0; i<theFramesectionTypes.size(); i++) {
+        theFramesectionInputs[theFramesectionTypes[i]]->outputToJSON(theFramesectionsArray);
+    }
     jsonObjProperties["framesections"]=theFramesectionsArray;
 
     //
@@ -342,10 +332,9 @@ InputWidgetSheetBM::clear(void)
     theSteelInput->clear();
     theConcreteInput->clear();
 
-    theConcreteRectColFSInput->clear();
-    theConcreteBoxColFSInput->clear();
-    theConcreteCircColFSInput->clear();
-    theConcretePipeColFSInput->clear();
+    for (int i=0; i<theFramesectionTypes.size(); i++) {
+        theFramesectionInputs[theFramesectionTypes[i]]->clear();
+    }
 
     theSlabsectionInput->clear();
     theWallsectionInput->clear();
@@ -382,10 +371,9 @@ InputWidgetSheetBM::inputFromJSON(QJsonObject &jsonObject)
    thePointInput->inputFromJSON(jsonObjProperties);
 
    QJsonArray theFramesectionsArray = jsonObjProperties["framesections"].toArray();
-   theConcreteRectColFSInput->inputFromJSON(theFramesectionsArray);
-   theConcreteBoxColFSInput->inputFromJSON(theFramesectionsArray);
-   theConcreteCircColFSInput->inputFromJSON(theFramesectionsArray);
-   theConcretePipeColFSInput->inputFromJSON(theFramesectionsArray);
+   for (int i=0; i<theFramesectionTypes.size(); i++) {
+       theFramesectionInputs[theFramesectionTypes[i]]->inputFromJSON(theFramesectionsArray);
+   }
 
    // first the materials
    // get the array and for every object in array determine it's type and get

--- a/InputSheetBM/InputWidgetSheetBM.h
+++ b/InputSheetBM/InputWidgetSheetBM.h
@@ -103,12 +103,10 @@ private:
     WallInputWidget *theWallInput;
     SteelInputWidget *theSteelInput;
     ConcreteInputWidget *theConcreteInput;
+
     QStringList theFramesectionTypes;
     QMap<QString, FramesectionInputWidget*> theFramesectionInputs;
-    FramesectionInputWidget *theConcreteRectColFSInput;
-    FramesectionInputWidget *theConcreteBoxColFSInput;
-    FramesectionInputWidget *theConcreteCircColFSInput;
-    FramesectionInputWidget *theConcretePipeColFSInput;
+
     SlabsectionInputWidget *theSlabsectionInput;
     WallsectionInputWidget *theWallsectionInput;
     ConnectionInputWidget *theConnectionInput;

--- a/InputSheetBM/InputWidgetSheetBM.h
+++ b/InputSheetBM/InputWidgetSheetBM.h
@@ -103,6 +103,8 @@ private:
     WallInputWidget *theWallInput;
     SteelInputWidget *theSteelInput;
     ConcreteInputWidget *theConcreteInput;
+    QStringList theFramesectionTypes;
+    QMap<QString, FramesectionInputWidget*> theFramesectionInputs;
     FramesectionInputWidget *theConcreteRectColFSInput;
     FramesectionInputWidget *theConcreteBoxColFSInput;
     FramesectionInputWidget *theConcreteCircColFSInput;

--- a/InputSheetBM/InputWidgetSheetBM.h
+++ b/InputSheetBM/InputWidgetSheetBM.h
@@ -108,8 +108,12 @@ private:
     QMap<QString, FramesectionInputWidget*> theFramesectionInputs;
 
     SlabsectionInputWidget *theSlabsectionInput;
-    WallsectionInputWidget *theWallsectionInput;
-    ConnectionInputWidget *theConnectionInput;
+
+    QStringList theWallsectionTypes;
+    QMap<QString, WallsectionInputWidget*> theWallsectionInputs;
+
+    QStringList theConnectionTypes;
+    QMap<QString, ConnectionInputWidget*> theConnectionInputs;
     PointInputWidget *thePointInput;
     RandomVariableInputWidget *theRVs;
 

--- a/InputSheetBM/InputWidgetSheetBM.h
+++ b/InputSheetBM/InputWidgetSheetBM.h
@@ -103,7 +103,10 @@ private:
     WallInputWidget *theWallInput;
     SteelInputWidget *theSteelInput;
     ConcreteInputWidget *theConcreteInput;
-    FramesectionInputWidget *theFramesectionInput;
+    FramesectionInputWidget *theConcreteRectColFSInput;
+    FramesectionInputWidget *theConcreteBoxColFSInput;
+    FramesectionInputWidget *theConcreteCircColFSInput;
+    FramesectionInputWidget *theConcretePipeColFSInput;
     SlabsectionInputWidget *theSlabsectionInput;
     WallsectionInputWidget *theWallsectionInput;
     ConnectionInputWidget *theConnectionInput;

--- a/InputSheetBM/PointInputWidget.cpp
+++ b/InputSheetBM/PointInputWidget.cpp
@@ -83,7 +83,7 @@ PointInputWidget::~PointInputWidget()
 
 }
 
-void
+bool
 PointInputWidget::outputToJSON(QJsonObject &jsonObj){
     using namespace std;
 
@@ -132,10 +132,10 @@ PointInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // add the object
     jsonObj["points"] = jsonArray;
-
+    return(true);
 }
 
-void
+bool
 PointInputWidget::inputFromJSON(QJsonObject &jsonObject){
 
     int currentRow = 0;
@@ -176,7 +176,7 @@ PointInputWidget::inputFromJSON(QJsonObject &jsonObject){
         currentRow++;
     }
 
-
+    return(true);
 }
 
 

--- a/InputSheetBM/PointInputWidget.h
+++ b/InputSheetBM/PointInputWidget.h
@@ -54,8 +54,8 @@ public:
     explicit PointInputWidget(SimCenterWidget *parent = 0);
     ~PointInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/README.md
+++ b/InputSheetBM/README.md
@@ -1,0 +1,16 @@
+Check out this commit: 1f9fcee
+
+Particularly changes to:
+
+- InputWidgetSheetBM.cpp
+- InputWidgetSheetBM.h
+- ConnectionInputWidget.cpp
+- ConnectionInputWidget.h
+
+for the pattern on how to make other widgets DRY-er and how to implement Slabsections (only one I didn't get to).
+
+Of particular note:
+
+1) the constructor that takes a connection type as `QString connectionType` in `ConnectionInputWidget.cpp`
+2) the `outputToJSON` and `inputFromJSON` member functions which take `QJsonArray` (rather than QJsonObject) in `ConnectionInputWidget.cpp` - pay attention to "bolt group ", or check out `FramesectionInputWidget.cpp` for an example of "longitudinal rebar " and "transverse rebar " field handling.
+3) the `QStringList theConnectionTypes`, defined in `InputWidgetSheetBM.cpp`, and the various places in that file `theConnectionTypes` is used to iterate over `QMap<QString, ConnectionInputWidget> theConnectionInputs`.

--- a/InputSheetBM/SlabsectionInputWidget.cpp
+++ b/InputSheetBM/SlabsectionInputWidget.cpp
@@ -127,7 +127,7 @@ SlabsectionInputWidget::~SlabsectionInputWidget()
 
 }
 
-void
+bool
 SlabsectionInputWidget::outputToJSON(QJsonObject &jsonObj){
 
 
@@ -256,10 +256,10 @@ SlabsectionInputWidget::outputToJSON(QJsonObject &jsonObj){
 
     // add the object
     jsonObj["slabsections"] = jsonArray;
-
+    return(true);
 }
 
-void
+bool
 SlabsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
 
     int currentRow = 0;
@@ -370,7 +370,7 @@ SlabsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
         currentRow++;
     }
 
-
+    return(true);
 }
 
 

--- a/InputSheetBM/SlabsectionInputWidget.cpp
+++ b/InputSheetBM/SlabsectionInputWidget.cpp
@@ -307,6 +307,7 @@ SlabsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
         lr_barArea = lrObject["bar area"].toDouble();
         lr_barAreaCorner = lrObject["bar area corner"].toDouble();
         lr_cover = lrObject["lr_cover"].toDouble();
+        lr_spacing = lrObject["lr_spacing"].toDouble();
 
         //********* FINISH THIS
 

--- a/InputSheetBM/SlabsectionInputWidget.cpp
+++ b/InputSheetBM/SlabsectionInputWidget.cpp
@@ -284,7 +284,7 @@ SlabsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
     // object in the array, get the values and add to the spreadsheet
     //
 
-    QJsonArray theArray = jsonObject["framesections"].toArray();
+    QJsonArray theArray = jsonObject["slabsections"].toArray();
     foreach (const QJsonValue &theValue, theArray) {
         // get values
         QJsonObject theObject = theValue.toObject();

--- a/InputSheetBM/SlabsectionInputWidget.h
+++ b/InputSheetBM/SlabsectionInputWidget.h
@@ -55,8 +55,8 @@ public:
     explicit SlabsectionInputWidget(SimCenterWidget *parent = 0);
     ~SlabsectionInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/SteelInputWidget.cpp
+++ b/InputSheetBM/SteelInputWidget.cpp
@@ -73,12 +73,12 @@ SteelInputWidget::~SteelInputWidget()
 }
 
 
-void
+bool
 SteelInputWidget::outputToJSON(QJsonObject &jsonObj){
-    return;
+    return(true);
 }
 
-void
+bool
 SteelInputWidget::outputToJSON(QJsonArray &jsonArray){
 
      // create a json array and for each row add a json object to it
@@ -115,9 +115,10 @@ SteelInputWidget::outputToJSON(QJsonArray &jsonArray){
         // add the object to the array
         jsonArray.append(obj);
     }
+    return(true);
 }
 
-void
+bool
 SteelInputWidget::inputFromJSON(QJsonObject &theObject)
 {
     // this has to be called one object at a time for efficiency
@@ -147,6 +148,7 @@ SteelInputWidget::inputFromJSON(QJsonObject &theObject)
 
         currentRow++;
     }
+    return(true);
 }
 
 void

--- a/InputSheetBM/SteelInputWidget.h
+++ b/InputSheetBM/SteelInputWidget.h
@@ -51,9 +51,9 @@ public:
     explicit SteelInputWidget(QWidget *parent = 0);
     ~SteelInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void outputToJSON(QJsonArray &arrayObject);
-    void inputFromJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonArray &arrayObject);
+    bool inputFromJSON(QJsonObject &rvObject);
     void clear(void);
 
 signals:

--- a/InputSheetBM/TestInputWidgetSheetBM.pro
+++ b/InputSheetBM/TestInputWidgetSheetBM.pro
@@ -64,8 +64,8 @@ HEADERS  += MainWindow.h\
 
 #FORMS    += mainwindow.ui
 
-RESOURCES += \
-    schema.qrc
+#RESOURCES += \
+#    schema.qrc
 
 
 

--- a/InputSheetBM/WallsectionInputWidget.cpp
+++ b/InputSheetBM/WallsectionInputWidget.cpp
@@ -77,10 +77,10 @@ WallsectionInputWidget::setupSpreadsheet() {
     this->setMinimumWidth(500);
 }
 
-void
-WallsectionInputWidget::outputToJSON(QJsonObject &jsonObj){return;}
+bool
+WallsectionInputWidget::outputToJSON(QJsonObject &jsonObj){return(true);}
 
-void
+bool
 WallsectionInputWidget::outputToJSON(QJsonArray &jsonArray) {
     int numRows = theSpreadsheet->getNumRows();
 
@@ -99,7 +99,7 @@ WallsectionInputWidget::outputToJSON(QJsonArray &jsonArray) {
                 if (theSpreadsheet->getString(i,j,tmpString) == false || tmpString.isEmpty()) {
                     qDebug() << "no value for " << fieldName << " in row " << i;
                     // TODO: need to actually break out of this loop
-                    return;
+                    return(true);
                 }
                 if (fieldName.startsWith("longitudinal rebar ") == true) {
                     lrebar[fieldName.remove(0,19)] = tmpString;
@@ -118,7 +118,7 @@ WallsectionInputWidget::outputToJSON(QJsonArray &jsonArray) {
                 if (theSpreadsheet->getDouble(i,j,tmpDouble) == false) {
                     qDebug() << "no value for " << fieldName << " in row " << i;
                     // TODO: need to actually break out of this loop
-                    return;
+                    return(true);
                 }
                 if (fieldName.startsWith("longitudinal rebar ") == true) {
                     lrebar[fieldName.remove(0,19)] = tmpDouble;
@@ -134,17 +134,19 @@ WallsectionInputWidget::outputToJSON(QJsonArray &jsonArray) {
             }
         }
 
-        if (!lrebar.isEmpty) { obj["longitudinal rebar"] = lrebar; }
-        if (!trebar.isEmpty) { obj["transverse rebar"] = trebar; }
-        if (!lber.isEmpty) { obj["longitudinal boundary element rebar"] = lber; }
-        if (!tber.isEmpty) { obj["transverse boundary element rebar"] = tber; }
+        if (!lrebar.isEmpty()) { obj["longitudinal rebar"] = lrebar; }
+        if (!trebar.isEmpty()) { obj["transverse rebar"] = trebar; }
+        if (!lber.isEmpty()) { obj["longitudinal boundary element rebar"] = lber; }
+        if (!tber.isEmpty()) { obj["transverse boundary element rebar"] = tber; }
         obj["type"] = wallsectionType;
         jsonArray.append(obj);
     }
 
+    return(true);
+
 }
 
-void
+bool
 WallsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
 
 
@@ -285,10 +287,10 @@ WallsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
         currentRow++;
     }
 
-
+    return(true);
 }
 
-void
+bool
 WallsectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
     int currentRow = 0;
 
@@ -309,9 +311,9 @@ WallsectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
                         tmpString = lrebar[fieldName.remove(0,19)].toString();
                     } else if (fieldName.startsWith("transverse rebar ") == true) {
                         tmpString = trebar[fieldName.remove(0,17)].toString();
-                    } else if (fieldName.startsWith("LBER ") == true) {
+                    } else if (fieldName.startsWith("lber ") == true) {
                         tmpString = lber[fieldName.remove(0,5)].toString();
-                    } else if (fieldName.startsWith("TBER ") == true) {
+                    } else if (fieldName.startsWith("tber ") == true) {
                         tmpString = tber[fieldName.remove(0,5)].toString();
                     } else {
                         tmpString = theObject[fieldName].toString();
@@ -323,9 +325,9 @@ WallsectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
                         tmpDouble = lrebar[fieldName.remove(0,19)].toDouble();
                     } else if (fieldName.startsWith("transverse rebar ") == true) {
                         tmpDouble = trebar[fieldName.remove(0,17)].toDouble();
-                    } else if (fieldName.startsWith("LBER ") == true) {
+                    } else if (fieldName.startsWith("lber ") == true) {
                         tmpDouble = lber[fieldName.remove(0,5)].toDouble();
-                    } else if (fieldName.startsWith("TBER") == true) {
+                    } else if (fieldName.startsWith("tber") == true) {
                         tmpDouble = tber[fieldName.remove(0,5)].toDouble();
                     } else {
                         tmpDouble = theObject[fieldName].toDouble();
@@ -336,6 +338,7 @@ WallsectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
             currentRow++;
         }
     }
+    return(true);
 }
 
 void

--- a/InputSheetBM/WallsectionInputWidget.cpp
+++ b/InputSheetBM/WallsectionInputWidget.cpp
@@ -364,6 +364,7 @@ WallsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
         lr_barArea = lrObject["bar area"].toDouble();
         lr_barAreaCorner = lrObject["bar area corner"].toDouble();
         lr_cover = lrObject["lr_cover"].toDouble();
+        lr_spacing = lrObject["lr_spacing"].toDouble();
 
         //********* FINISH THIS
 

--- a/InputSheetBM/WallsectionInputWidget.cpp
+++ b/InputSheetBM/WallsectionInputWidget.cpp
@@ -340,7 +340,7 @@ WallsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
     // object in the array, get the values and add to the spreadsheet
     //
 
-    QJsonArray theArray = jsonObject["framesections"].toArray();
+    QJsonArray theArray = jsonObject["wallsections"].toArray();
     foreach (const QJsonValue &theValue, theArray) {
         // get values
         QJsonObject theObject = theValue.toObject();

--- a/InputSheetBM/WallsectionInputWidget.cpp
+++ b/InputSheetBM/WallsectionInputWidget.cpp
@@ -1,4 +1,3 @@
-
 /* *****************************************************************************
 Copyright (c) 2016-2017, The Regents of the University of California (Regents).
 All rights reserved.
@@ -37,107 +36,32 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 // Written: mmanning
 
-
 #include "WallsectionInputWidget.h"
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QDebug>
 #include <QList>
 
+//Constructor takes the name for this type of wallsection and a SimCenterWidget
+//WallsectionInputWidget class implementation contains details about what fields
+//are included for each wallsection type
+WallsectionInputWidget::WallsectionInputWidget(QString wallsectionType, SimCenterWidget *parent) : SimCenterTableWidget(parent) {
+    if (wallsectionType == "concrete rectangular wall") { this->concreteRectWallWS(); }
+    if (wallsectionType == "concrete flanged wall") { this->concreteFlangedWallWS(); }
+    if (wallsectionType == "concrete barbell wall") { this->concreteBarbellWallWS(); }
 
-WallsectionInputWidget::WallsectionInputWidget(SimCenterWidget *parent) : SimCenterTableWidget(parent)
-{
-    theLayout = new QHBoxLayout();
-    this->setLayout(theLayout);
-
-    QStringList headings;
-    QList<int> dataTypes;
-    headings << tr("Name");
-    headings << tr("Type");
-
-    headings << tr("Length");
-    headings << tr("Thickness");
-    headings << tr("Boundary element length");
-    headings << tr("Mass per area");
-
-    headings << tr("longitudinal rebar material");
-    headings << tr("longitudinal rebar material corner");
-    headings << tr("longitudinal rebar num bars depth");
-    headings << tr("longitudinal rebar num bars width");
-    headings << tr("longitudinal rebar bar area");
-    headings << tr("longitudinal rebar bar area corner");
-    headings << tr("longitudinal rebar cover");
-
-    headings << tr("transverse rebar material");
-    headings << tr("transverse rebar num bars depth");
-    headings << tr("transverse rebar num bars width");
-    headings << tr("transverse rebar num bars thickness");
-    headings << tr("transverse rebar bar area");
-    headings << tr("transverse rebar spacing");
-    headings << tr("transverse rebar cover");
-
-    //longitudinal boundary element rebar (LBER)
-    headings << tr("LBER material");
-    headings << tr("LBER num bars length");
-    headings << tr("LBER num bars thickness");
-    headings << tr("LBER bar area");
-    headings << tr("LBER spacing");
-
-    //transverse boundary element rebar (TBER)
-    headings << tr("TBER material");
-    headings << tr("TBER num bars length");
-    headings << tr("TBER num bars thickness");
-    headings << tr("TBER bar area");
-    headings << tr("TBER spacing");
-
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QString;
-
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    // longitudinal rebar
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    // transverse rebar
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    //longitudinal boundary element rebar
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    //transverse boundary element rebar
-    dataTypes << SIMPLESPREADSHEET_QString;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-    dataTypes << SIMPLESPREADSHEET_QDouble;
-
-    theSpreadsheet = new SpreadsheetWidget(28, 1000, headings, dataTypes, this);
-
-    theLayout->addWidget(theSpreadsheet);
-
-    this->setMinimumWidth(500);
-
-
+    this->setupSpreadsheet();
 }
 
+//Constructor takes a string list of column headings, an integer list of data types,
+//the name for this type of wallsection, and a SimCenterWidget
+WallsectionInputWidget::WallsectionInputWidget(QStringList headings, QList<int> dataTypes, QString wallsectionType, SimCenterWidget *parent) : SimCenterTableWidget(parent) {
+    this->tableHeader = headings;
+    this->dataTypes = dataTypes;
+    this->wallsectionType = wallsectionType;
 
+    this->setupSpreadsheet();
+}
 
 WallsectionInputWidget::~WallsectionInputWidget()
 {
@@ -145,168 +69,78 @@ WallsectionInputWidget::~WallsectionInputWidget()
 }
 
 void
-WallsectionInputWidget::outputToJSON(QJsonObject &jsonObj){
+WallsectionInputWidget::setupSpreadsheet() {
+    theLayout = new QHBoxLayout();
+    this->setLayout(theLayout);
+    theSpreadsheet = new SpreadsheetWidget(tableHeader.size(), 1000, tableHeader, dataTypes, this);
+    theLayout->addWidget(theSpreadsheet);
+    this->setMinimumWidth(500);
+}
 
-    QJsonArray  jsonArray;
+void
+WallsectionInputWidget::outputToJSON(QJsonObject &jsonObj){return;}
+
+void
+WallsectionInputWidget::outputToJSON(QJsonArray &jsonArray) {
     int numRows = theSpreadsheet->getNumRows();
+
+    // for each row of the spreadsheet
     for (int i=0; i<numRows; i++) {
+        QJsonObject obj, lrebar, trebar, lber, tber;
+        // for each field defined in private member var tableHeader
+        // and the respective data type defined in private member var dataTypes
+        // (tableHeader and dataTypes defined in constructor function)
+        for (int j=0; j<tableHeader.size(); j++) {
+            QString fieldName = tableHeader[j].toLower();
 
-        QJsonObject obj;
-        QString name, ws_type;
-        double ws_thickness, bel, massperarea;
+            if(dataTypes[j] == 0) {
+                //string
+                QString tmpString;
+                if (theSpreadsheet->getString(i,j,tmpString) == false || tmpString.isEmpty()) {
+                    qDebug() << "no value for " << fieldName << " in row " << i;
+                    // TODO: need to actually break out of this loop
+                    return;
+                }
+                if (fieldName.startsWith("longitudinal rebar ") == true) {
+                    lrebar[fieldName.remove(0,19)] = tmpString;
+                } else if (fieldName.startsWith("transverse rebar ") == true) {
+                    trebar[fieldName.remove(0,17)] = tmpString;
+                } else if (fieldName.startsWith("lber ") == true) {
+                    lber[fieldName.remove(0,5)] = tmpString;
+                } else if (fieldName.startsWith("tber ") == true) {
+                    tber[fieldName.remove(0,5)] = tmpString;
+                } else {
+                    obj[fieldName] = tmpString;
+                }
+            } else if (dataTypes[j] == 1) {
+                //double
+                double tmpDouble;
+                if (theSpreadsheet->getDouble(i,j,tmpDouble) == false) {
+                    qDebug() << "no value for " << fieldName << " in row " << i;
+                    // TODO: need to actually break out of this loop
+                    return;
+                }
+                if (fieldName.startsWith("longitudinal rebar ") == true) {
+                    lrebar[fieldName.remove(0,19)] = tmpDouble;
+                } else if (fieldName.startsWith("transverse rebar ") == true) {
+                    trebar[fieldName.remove(0,17)] = tmpDouble;
+                } else if (fieldName.startsWith("lber ") == true) {
+                    lber[fieldName.remove(0,5)] = tmpDouble;
+                } else if (fieldName.startsWith("tber ") == true) {
+                    tber[fieldName.remove(0,5)] = tmpDouble;
+                } else {
+                    obj[fieldName] = tmpDouble;
+                }
+            }
+        }
 
-        // longitudinal rebar
-        QString lr_material, lr_materialCorner;
-        double lr_numBarsDepth, lr_numBarsWidth, lr_barArea, lr_barAreaCorner, lr_cover;
-
-        // transverse rebar
-        QString tr_material;
-        double tr_numBarsDepth, tr_numBarsWidth, tr_numBarsThickness, tr_barArea, tr_barAreaCorner, tr_spacing, tr_cover;
-
-        //longitudinal boundary element rebar (LBER)
-        QString lber_material;
-        double  lber_numBarsLength, lber_numBarsThickness, lber_barArea, lber_spacing;
-
-        //transverse boundary element rebar (TBER)
-        QString tber_material;
-        double  tber_numBarsLength, tber_numBarsThickness, tber_barArea, tber_spacing;
-
-
-        // obtain info from spreadsheet
-        if (theSpreadsheet->getString(i,0,name) == false || name.isEmpty())
-            break;
-        if (theSpreadsheet->getString(i,1,ws_type) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,2, ws_thickness) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,3,bel) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,4,massperarea) == false)
-            break;
-
-        // longitudinal rebar  ********* FIX THIS ************* then renumber!!!
-        if (theSpreadsheet->getString(i,19,lr_material) == false)
-            break;
-        if (theSpreadsheet->getString(i,20,lr_materialCorner) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,12,lr_numBarsDepth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,13,lr_numBarsWidth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,14,lr_barArea) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,15,lr_barAreaCorner) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,16,lr_cover) == false)
-            break;
-
-        // transverse rebar
-        if (theSpreadsheet->getString(i,00,tr_material) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tr_numBarsDepth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tr_numBarsWidth) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tr_numBarsThickness) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tr_barArea) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tr_barAreaCorner) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tr_spacing) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tr_cover) == false)
-            break;
-
-        //longitudinal boundary element rebar
-        if (theSpreadsheet->getString(i,00,lber_material) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,lber_numBarsLength) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,lber_numBarsThickness) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,lber_barArea) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,lber_spacing) == false)
-            break;
-
-        //transverse boundary element rebar
-        if (theSpreadsheet->getString(i,00,tber_material) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tber_numBarsLength) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tber_numBarsThickness) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tber_barArea) == false)
-            break;
-        if (theSpreadsheet->getDouble(i,00,tber_spacing) == false)
-            break;
-
-
-        // now add the items to object
-        obj["name"]=name;
-        obj["type"]=ws_type;
-        obj["material"]=ws_thickness;
-        obj["depth"]=bel;
-        obj["width"]=massperarea;
-
-        // longitudinal rebar   -FIX THIS!!!!!!! todo
-        QJsonObject lrebar;
-
-        lrebar["material"]=tr_material;
-        lrebar["material corner"]=lr_materialCorner;
-        lrebar["num bars depth"]=lr_numBarsDepth;
-        lrebar["num bars width"]=lr_numBarsWidth;
-        lrebar["bar area"]=lr_barArea;
-        lrebar["bar area corner"]=lr_barAreaCorner;
-
-        lrebar["longitudinal rebar"] = lrebar;
-
-        // transverse rebar
-        QJsonObject trebar;
-
-        trebar["material"]=tr_material;
-        trebar["bar area"]=tr_barArea;
-        trebar["bar area corner"]=tr_barAreaCorner;
-        trebar["spacing"]=tr_spacing;
-        trebar["cover"]=tr_cover;
-        trebar["num bars depth"]=tr_numBarsDepth;
-        trebar["num bars width"]=tr_numBarsWidth;
-        trebar["num bars thickness"]=tr_numBarsThickness;
-
-        obj["transverse rebar"] = trebar;
-
-
-        // longitudinal boundary element rebar
-        QJsonObject lberrebar;
-
-        lberrebar["material"]=lber_material;
-        lberrebar["num bars length"]=lber_numBarsLength;
-        lberrebar["num bars thickness"]=lber_numBarsThickness;
-        lberrebar["bar area"]=lber_barArea;
-        lberrebar["lber_spacing"]=lber_spacing;
-
-
-        obj["longitudinal boundary element rebar"] = lberrebar;
-
-        // transverse boundary element rebar
-        QJsonObject tberrebar;
-
-        lberrebar["material"]=tber_material;
-        lberrebar["num bars length"]=tber_numBarsLength;
-        lberrebar["num bars thickness"]=tber_numBarsThickness;
-        lberrebar["bar area"]=tber_barArea;
-        lberrebar["lber_spacing"]=tber_spacing;
-
-
-        obj["longitudinal boundary element rebar"] = lberrebar;
-
-        // add the object to the array
+        if (!lrebar.isEmpty) { obj["longitudinal rebar"] = lrebar; }
+        if (!trebar.isEmpty) { obj["transverse rebar"] = trebar; }
+        if (!lber.isEmpty) { obj["longitudinal boundary element rebar"] = lber; }
+        if (!tber.isEmpty) { obj["transverse boundary element rebar"] = tber; }
+        obj["type"] = wallsectionType;
         jsonArray.append(obj);
     }
-
-    // add the object
-    jsonObj["wallsections"] = jsonArray;
 
 }
 
@@ -454,9 +288,253 @@ WallsectionInputWidget::inputFromJSON(QJsonObject &jsonObject){
 
 }
 
+void
+WallsectionInputWidget::inputFromJSON(QJsonArray &jsonArray) {
+    int currentRow = 0;
+
+    foreach (const QJsonValue &theValue, jsonArray) {
+        QJsonObject theObject = theValue.toObject();
+        if (theObject["type"] == wallsectionType) {
+            QJsonObject lrebar = theObject["longitudinal rebar"].toObject();
+            QJsonObject trebar = theObject["transverse rebar"].toObject();
+            QJsonObject lber = theObject["longitudinal boundary element rebar"].toObject();
+            QJsonObject tber = theObject["transverse boundary element rebar"].toObject();
+
+            for (int j=0; j<tableHeader.size(); j++) {
+                QString fieldName = tableHeader[j].toLower();
+
+                if(dataTypes[j] == 0) {
+                    QString tmpString;
+                    if(fieldName.startsWith("longitudinal rebar ") == true) {
+                        tmpString = lrebar[fieldName.remove(0,19)].toString();
+                    } else if (fieldName.startsWith("transverse rebar ") == true) {
+                        tmpString = trebar[fieldName.remove(0,17)].toString();
+                    } else if (fieldName.startsWith("LBER ") == true) {
+                        tmpString = lber[fieldName.remove(0,5)].toString();
+                    } else if (fieldName.startsWith("TBER ") == true) {
+                        tmpString = tber[fieldName.remove(0,5)].toString();
+                    } else {
+                        tmpString = theObject[fieldName].toString();
+                    }
+                    theSpreadsheet->setString(currentRow, j, tmpString);
+                } else if (dataTypes[j] == 1) {
+                    double tmpDouble;
+                    if(fieldName.startsWith("longitudinal rebar ") == true) {
+                        tmpDouble = lrebar[fieldName.remove(0,19)].toDouble();
+                    } else if (fieldName.startsWith("transverse rebar ") == true) {
+                        tmpDouble = trebar[fieldName.remove(0,17)].toDouble();
+                    } else if (fieldName.startsWith("LBER ") == true) {
+                        tmpDouble = lber[fieldName.remove(0,5)].toDouble();
+                    } else if (fieldName.startsWith("TBER") == true) {
+                        tmpDouble = tber[fieldName.remove(0,5)].toDouble();
+                    } else {
+                        tmpDouble = theObject[fieldName].toDouble();
+                    }
+                    theSpreadsheet->setDouble(currentRow, j, tmpDouble);
+                }
+            }
+            currentRow++;
+        }
+    }
+}
 
 void
 WallsectionInputWidget::clear(void)
 {
     theSpreadsheet->clear();
+}
+
+void
+WallsectionInputWidget::concreteRectWallWS() {
+    QStringList concreteRectWallWSHeadings;
+    QList<int> concreteRectWallWSDataTypes;
+    this->wallsectionType = "concrete rectangular wall";
+
+    concreteRectWallWSHeadings << tr("Name");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectWallWSHeadings << tr("length");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("thickness");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("boundary element length");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("longitudinal rebar material");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectWallWSHeadings << tr("longitudinal rebar num bars thickness");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("longitudinal rebar bar area");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("longitudinal rebar spacing");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("longitudinal rebar cover");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("transverse rebar material");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectWallWSHeadings << tr("transverse rebar num bars thickness");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("transverse rebar bar area");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("transverse rebar spacing");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("transverse rebar cover");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("LBER material");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectWallWSHeadings << tr("LBER num bars length");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("LBER num bars thickness");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("LBER bar area");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("LBER cover");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("TBER material");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteRectWallWSHeadings << tr("TBER num bars length");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("TBER num bars thickness");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("TBER bar area");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("TBER spacing");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteRectWallWSHeadings << tr("mass per area");
+    concreteRectWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteRectWallWSHeadings;
+    this->dataTypes = concreteRectWallWSDataTypes;
+}
+
+void
+WallsectionInputWidget::concreteFlangedWallWS() {
+    QStringList concreteFlangedWallWSHeadings;
+    QList<int> concreteFlangedWallWSDataTypes;
+    this->wallsectionType = "concrete flanged wall";
+
+    concreteFlangedWallWSHeadings << tr("Name");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteFlangedWallWSHeadings << tr("length");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("flange width");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("flange thickness");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("web thickness");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("boundary element length");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("longitudinal rebar material");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteFlangedWallWSHeadings << tr("longitudinal rebar num bars thickness");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("longitudinal rebar bar area");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("longitudinal rebar spacing");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("longitudinal rebar cover");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("transverse rebar material");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteFlangedWallWSHeadings << tr("transverse rebar num bars thickness");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("transverse rebar bar area");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("transverse rebar spacing");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("transverse rebar cover");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("LBER material");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteFlangedWallWSHeadings << tr("LBER num bars length");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("LBER num bars thickness");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("LBER bar area");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("LBER cover");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("TBER material");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteFlangedWallWSHeadings << tr("TBER num bars length");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("TBER num bars thickness");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("TBER bar area");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("TBER spacing");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteFlangedWallWSHeadings << tr("mass per area");
+    concreteFlangedWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteFlangedWallWSHeadings;
+    this->dataTypes = concreteFlangedWallWSDataTypes;
+}
+
+void
+WallsectionInputWidget::concreteBarbellWallWS() {
+    QStringList concreteBarbellWallWSHeadings;
+    QList<int> concreteBarbellWallWSDataTypes;
+    this->wallsectionType = "concrete barbell wall";
+
+    concreteBarbellWallWSHeadings << tr("Name");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBarbellWallWSHeadings << tr("length");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("top flange width");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("top flange thickness");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("web thickness");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("bottom flange width");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("bottom flange thickness");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("boundary element length");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("longitudinal rebar material");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBarbellWallWSHeadings << tr("longitudinal rebar num bars thickness");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("longitudinal rebar bar area");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("longitudinal rebar spacing");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("longitudinal rebar cover");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("transverse rebar material");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBarbellWallWSHeadings << tr("transverse rebar num bars thickness");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("transverse rebar bar area");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("transverse rebar spacing");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("transverse rebar cover");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("LBER material");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBarbellWallWSHeadings << tr("LBER num bars length");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("LBER num bars thickness");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("LBER bar area");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("LBER cover");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("TBER material");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QString;
+    concreteBarbellWallWSHeadings << tr("TBER num bars length");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("TBER num bars thickness");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("TBER bar area");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("TBER spacing");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+    concreteBarbellWallWSHeadings << tr("mass per area");
+    concreteBarbellWallWSDataTypes << SIMPLESPREADSHEET_QDouble;
+
+    this->tableHeader = concreteBarbellWallWSHeadings;
+    this->dataTypes = concreteBarbellWallWSDataTypes;
 }

--- a/InputSheetBM/WallsectionInputWidget.h
+++ b/InputSheetBM/WallsectionInputWidget.h
@@ -54,10 +54,16 @@ class WallsectionInputWidget : public SimCenterTableWidget
 public:
 
     explicit WallsectionInputWidget(SimCenterWidget *parent = 0);
+    explicit WallsectionInputWidget(QString wallsectionType, SimCenterWidget *parent = 0);
+    explicit WallsectionInputWidget(QStringList headings, QList<int> dataTypes, QString wallsectionType, SimCenterWidget *parent = 0);
+
+
     ~WallsectionInputWidget();
 
     void outputToJSON(QJsonObject &rvObject);
+    void outputToJSON(QJsonArray &rvObject);
     void inputFromJSON(QJsonObject &rvObject);
+    void inputFromJSON(QJsonArray &rvObject);
     void clear(void);
 
 signals:
@@ -67,8 +73,13 @@ public slots:
 private:
     QHBoxLayout *theLayout;
     QStringList   tableHeader;
+    QList<int> dataTypes;
+    QString wallsectionType;
 
-
+    void setupSpreadsheet();
+    void concreteRectWallWS();
+    void concreteFlangedWallWS();
+    void concreteBarbellWallWS();
 };
 
 #endif // WALLSECTIONINPUTWIDGET_H

--- a/InputSheetBM/WallsectionInputWidget.h
+++ b/InputSheetBM/WallsectionInputWidget.h
@@ -60,10 +60,10 @@ public:
 
     ~WallsectionInputWidget();
 
-    void outputToJSON(QJsonObject &rvObject);
-    void outputToJSON(QJsonArray &rvObject);
-    void inputFromJSON(QJsonObject &rvObject);
-    void inputFromJSON(QJsonArray &rvObject);
+    bool outputToJSON(QJsonObject &rvObject);
+    bool outputToJSON(QJsonArray &rvObject);
+    bool inputFromJSON(QJsonObject &rvObject);
+    bool inputFromJSON(QJsonArray &rvObject);
     void clear(void);
 
 signals:

--- a/RandomVariables/RandomVariables.pri
+++ b/RandomVariables/RandomVariables.pri
@@ -27,7 +27,7 @@ HEADERS += $$PWD/RandomVariableDistribution.h \
     $$PWD/BetaDistribution.h \
     $$PWD/RandomVariableInputWidget.h \
     $$PWD/UniformDistribution.h \
-    $$PWD/ConstantDustribution.h \
+    $$PWD/ConstantDistribution.h \
     $$PWD/ContinuousDesignDistribution.h \
     $$PWD/ConstantDistribution.h
 


### PR DESCRIPTION
Check out this commit: 1f9fcee45c3a304dd07ee60e2f93909c884c4440

Particularly changes to: 
- InputWidgetSheetBM.cpp
- InputWidgetSheetBM.h
- ConnectionInputWidget.cpp
- ConnectionInputWidget.h

for the pattern on how to make other widgets DRY-er and how to implement Slabsections (only one I didn't get to). 

Of particular note:
1) the constructor that takes a connection type as `QString connectionType` in `ConnectionInputWidget.cpp`
2) the `outputToJSON` and `inputFromJSON` member functions which take `QJsonArray` (rather than `QJsonObject`) in `ConnectionInputWidget.cpp` - pay attention to "bolt group ", or check out FramesectionInputWidget.cpp for an example of "longitudinal rebar " and "transverse rebar " field handling. 
3) the `QStringList theConnectionTypes`, defined in `InputWidgetSheetBM.cpp`, and the various places in that file `theConnectionTypes` is used to iterate over `QMap<QString, ConnectionInputWidget> theConnectionInputs`.